### PR TITLE
Add group admin

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  images: {
+      images: {
+    deviceSizes: [
+      320, 480, 640, 750, 828, 1080, 1200, 1920, 2048, 3840,
+    ],
+    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
     remotePatterns: [
       {
         protocol: 'https',

--- a/src/app/(main)/admin/groups/[slug]/edit/members/page.tsx
+++ b/src/app/(main)/admin/groups/[slug]/edit/members/page.tsx
@@ -1,62 +1,63 @@
-import prisma from '@/lib/prisma';
-import { notFound } from 'next/navigation';
-import { auth } from '@/auth';
-import { getPublicUrl } from '@/lib/storage';
-import GroupMembers, { GroupMember } from '../group-members';
+import prisma from '@/lib/prisma'
+import { notFound } from 'next/navigation'
+import { auth } from '@/auth'
+import { getPublicUrl } from '@/lib/storage'
+import GroupMembers, { GroupMember } from '../group-members'
 
-import type { GroupWithMembers } from '@/types/index';
+import type { GroupWithMembers } from '@/types/index'
 
-const MEMBERS_PER_PAGE = 25;
+const MEMBERS_PER_PAGE = 25
 
-export default async function ManageMembersPage({ 
+export default async function ManageMembersPage({
   params: paramsProp,
   searchParams: searchParamsProp,
 }: {
-  params: Promise<{ slug: string }>;
-  searchParams?: Promise<{ page?: string }>;
+  params: Promise<{ slug: string }>
+  searchParams?: Promise<{ page?: string }>
 }) {
-  const params = await paramsProp;
-  const searchParams = await searchParamsProp;
-  const page = Number(searchParams?.page) || 1;
+  const params = await paramsProp
+  const searchParams = await searchParamsProp
+  const page = Number(searchParams?.page) || 1
 
-  const session = await auth();
-  const isSuperAdmin = session?.user?.isSuperAdmin;
+  const session = await auth()
+  const isSuperAdmin = session?.user?.isSuperAdmin
 
   if (!isSuperAdmin) {
-    notFound();
+    notFound()
   }
 
   const group = await prisma.group.findUnique({
     where: { slug: params.slug },
-  });
+  })
 
   if (!group) {
-    notFound();
+    notFound()
   }
 
-  const [totalMembers, members, groupUserRoles, entityTypes, photoTypes] = await prisma.$transaction([
-    prisma.groupUser.count({ where: { groupId: group.id } }),
-    prisma.groupUser.findMany({
-      where: { groupId: group.id },
-      include: {
-        role: true,
-        user: true,
-      },
-      take: MEMBERS_PER_PAGE,
-      skip: (page - 1) * MEMBERS_PER_PAGE,
-      orderBy: {
-        createdAt: 'desc',
-      },
-    }),
-    prisma.groupUserRole.findMany({ where: { groupId: null } }),
-    prisma.entityType.findMany({ where: { groupId: null } }),
-    prisma.photoType.findMany({ where: { groupId: null } }),
-  ]);
+  const [totalMembers, members, groupUserRoles, entityTypes, photoTypes] =
+    await prisma.$transaction([
+      prisma.groupUser.count({ where: { groupId: group.id } }),
+      prisma.groupUser.findMany({
+        where: { groupId: group.id },
+        include: {
+          role: true,
+          user: true,
+        },
+        take: MEMBERS_PER_PAGE,
+        skip: (page - 1) * MEMBERS_PER_PAGE,
+        orderBy: {
+          createdAt: 'desc',
+        },
+      }),
+      prisma.groupUserRole.findMany({ where: { groupId: null } }),
+      prisma.entityType.findMany({ where: { groupId: null } }),
+      prisma.photoType.findMany({ where: { groupId: null } }),
+    ])
 
-  const userEntityType = entityTypes.find(et => et.code === 'user');
-  const primaryPhotoType = photoTypes.find(pt => pt.code === 'primary');
+  const userEntityType = entityTypes.find((et) => et.code === 'user')
+  const primaryPhotoType = photoTypes.find((pt) => pt.code === 'primary')
 
-  const userIds = members.map((member) => member.userId);
+  const userIds = members.map((member) => member.userId)
   const photos = await prisma.photo.findMany({
     where: {
       entityId: { in: userIds },
@@ -67,42 +68,46 @@ export default async function ManageMembersPage({
       entityId: true,
       url: true,
     },
-  });
+  })
 
-  const photoUrlMap = new Map<string, string>();
+  const photoUrlMap = new Map<string, string>()
   for (const photo of photos) {
     if (photo.entityId) {
-      photoUrlMap.set(photo.entityId, photo.url);
+      photoUrlMap.set(photo.entityId, photo.url)
     }
   }
 
-  const totalPages = Math.ceil(totalMembers / MEMBERS_PER_PAGE);
-  const isGlobalAdminGroup = group.slug === 'global-admin';
+  const totalPages = Math.ceil(totalMembers / MEMBERS_PER_PAGE)
+  const isGlobalAdminGroup = group.slug === 'global-admin'
 
-  const membersWithPhoto = await Promise.all(members.map(async (member) => {
-    const rawUrl = photoUrlMap.get(member.userId);
-    let photoUrl: string;
-    if (rawUrl) {
-      if (rawUrl.startsWith('http')) {
-        photoUrl = rawUrl;
+  const membersWithPhoto = await Promise.all(
+    members.map(async (member) => {
+      const rawUrl = photoUrlMap.get(member.userId)
+      let photoUrl: string
+      if (rawUrl) {
+        if (rawUrl.startsWith('http')) {
+          photoUrl = rawUrl
+        } else {
+          photoUrl = await getPublicUrl(rawUrl)
+        }
       } else {
-        photoUrl = await getPublicUrl(rawUrl);
+        photoUrl = `https://api.dicebear.com/8.x/personas/png?seed=${member.user.id}`
       }
-    } else {
-      photoUrl = `https://api.dicebear.com/8.x/personas/png?seed=${member.user.id}`;
-    }
-    return {
-      ...member,
-      user: {
-        ...member.user,
-        photoUrl,
-      },
-    };
-  }));
+      return {
+        ...member,
+        user: {
+          ...member.user,
+          photoUrl,
+        },
+      }
+    }),
+  )
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4">Manage Members for {group.name}</h1>
+      <h1 className="mb-4 text-2xl font-bold">
+        Manage Members for {group.name}
+      </h1>
       <GroupMembers
         group={group as GroupWithMembers}
         members={membersWithPhoto as GroupMember[]}
@@ -114,5 +119,5 @@ export default async function ManageMembersPage({
         groupUserRoles={groupUserRoles}
       />
     </div>
-  );
+  )
 }

--- a/src/app/g/[slug]/admin/actions.ts
+++ b/src/app/g/[slug]/admin/actions.ts
@@ -1,0 +1,119 @@
+'use server';
+
+import prisma from '@/lib/prisma';
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { z } from 'zod';
+
+import { uploadFile, deleteFile } from '@/lib/storage';
+import { auth } from '@/auth';
+import { getCodeTable } from '@/lib/codes';
+import { isAdmin } from '@/lib/auth-utils';
+
+// Define the schema for form validation using Zod
+const GroupSchema = z.object({
+  name: z.string().min(1, 'Name is required.'),
+  slug: z.string().min(1, 'Slug is required.'),
+  description: z.string().optional(),
+  address: z.string().optional(),
+  phone: z.string().optional(),
+  logo: z.instanceof(File).optional(),
+});
+
+export async function updateGroup(formData: FormData) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    throw new Error('You must be logged in to update a group.');
+  }
+  const userId = session.user.id;
+  const groupId = Number(formData.get('groupId'));
+
+  const isGroupAdmin = await isAdmin(userId, groupId);
+  if (!isGroupAdmin) {
+    throw new Error('You do not have permission to update this group.');
+  }
+
+  // Extract and validate data
+  const validatedFields = GroupSchema.safeParse({
+    name: formData.get('name'),
+    slug: formData.get('slug'),
+    description: formData.get('description'),
+    address: formData.get('address'),
+    phone: formData.get('phone'),
+    logo: formData.get('logo'),
+  });
+
+  if (!validatedFields.success) {
+    // Handle validation errors
+    console.error(validatedFields.error);
+    throw new Error('Invalid form data.');
+  }
+
+  const { logo, ...groupData } = validatedFields.data;
+
+  try {
+    const updatedGroup = await prisma.group.update({
+      where: { id: groupId },
+      data: {
+        ...groupData,
+        updatedById: userId,
+      },
+    });
+
+    if (logo && logo.size > 0) {
+      const [entityTypes, photoTypes] = await Promise.all([
+        getCodeTable('entityType'),
+        getCodeTable('photoType'),
+      ]);
+
+      const groupEntityType = entityTypes.group;
+      const logoPhotoType = photoTypes.logo;
+
+      if (!groupEntityType || !logoPhotoType) {
+        throw new Error('Database Error: Could not find required code table entries.');
+      }
+
+      const existingLogo = await prisma.photo.findFirst({
+        where: {
+          entityTypeId: groupEntityType.id,
+          entityId: updatedGroup.id.toString(),
+          typeId: logoPhotoType.id,
+        },
+      });
+
+      const logoPath = await uploadFile(logo, 'groups', updatedGroup.id.toString());
+
+      if (existingLogo) {
+        await prisma.photo.update({
+          where: { id: existingLogo.id },
+          data: {
+            url: logoPath,
+            userId: userId,
+          },
+        });
+        // After successfully updating the DB, delete the old image.
+        if (existingLogo.url) {
+          await deleteFile(existingLogo.url);
+        }
+      } else {
+        await prisma.photo.create({
+          data: {
+            url: logoPath,
+            typeId: logoPhotoType.id,
+            entityTypeId: groupEntityType.id,
+            entityId: updatedGroup.id.toString(),
+            groupId: updatedGroup.id,
+            userId: userId,
+          },
+        });
+      }
+    }
+  } catch (error) {
+    console.error('Database Error:', error);
+    throw new Error('Failed to update group.');
+  }
+
+  revalidatePath(`/g/${groupData.slug}`);
+  revalidatePath(`/g/${groupData.slug}/admin`);
+  redirect(`/g/${groupData.slug}/admin`);
+}

--- a/src/app/g/[slug]/admin/actions.ts
+++ b/src/app/g/[slug]/admin/actions.ts
@@ -117,3 +117,26 @@ export async function updateGroup(formData: FormData) {
   revalidatePath(`/g/${groupData.slug}/admin`);
   redirect(`/g/${groupData.slug}/admin`);
 }
+
+export async function getGroupAdmins(groupId: number) {
+  const adminRole = await prisma.groupUserRole.findFirst({
+    where: { code: 'admin' },
+    select: { id: true },
+  });
+
+  if (!adminRole) {
+    return [];
+  }
+
+  const admins = await prisma.groupUser.findMany({
+    where: {
+      groupId: groupId,
+      roleId: adminRole.id,
+    },
+    include: {
+      user: true,
+    },
+  });
+
+  return admins.map((admin) => admin.user);
+}

--- a/src/app/g/[slug]/admin/edit-group-form.tsx
+++ b/src/app/g/[slug]/admin/edit-group-form.tsx
@@ -13,6 +13,7 @@ export default function EditGroupForm({
   logoUrl?: string
 }) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const [slugValue, setSlugValue] = useState(group.slug)
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]
@@ -57,13 +58,16 @@ export default function EditGroupForm({
           id="slug"
           name="slug"
           defaultValue={group.slug}
+          onChange={(e) => setSlugValue(e.target.value)}
           required
           className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none sm:text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400"
         />
-        <p className="mt-2 text-sm text-red-500 dark:text-red-400">
-          Warning: Changing the slug will break your current group URL and any
-          bookmarks to it that members may have.
-        </p>
+        {slugValue !== group.slug && (
+          <p className="mt-2 text-sm text-red-500 dark:text-red-400">
+            Warning: Changing the slug will break your current group URL and any
+            bookmarks to it that members may have.
+          </p>
+        )}
       </div>
       <div>
         <label

--- a/src/app/g/[slug]/admin/edit-group-form.tsx
+++ b/src/app/g/[slug]/admin/edit-group-form.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { useState } from 'react'
+import { updateGroup } from './actions'
+import type { Group } from '@/generated/prisma'
+import Image from 'next/image'
+
+export default function EditGroupForm({
+  group,
+  logoUrl,
+}: {
+  group: Group
+  logoUrl?: string
+}) {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (file) {
+      const reader = new FileReader()
+      reader.onloadend = () => {
+        setPreviewUrl(reader.result as string)
+      }
+      reader.readAsDataURL(file)
+    } else {
+      setPreviewUrl(null)
+    }
+  }
+  return (
+    <form action={updateGroup} className="space-y-6">
+      <input type="hidden" name="groupId" value={group.id} />
+      <div>
+        <label
+          htmlFor="name"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Name
+        </label>
+        <input
+          type="text"
+          id="name"
+          name="name"
+          defaultValue={group.name}
+          required
+          className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none sm:text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400"
+        />
+      </div>
+      <div>
+        <label
+          htmlFor="slug"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Slug
+        </label>
+        <input
+          type="text"
+          id="slug"
+          name="slug"
+          defaultValue={group.slug}
+          required
+          className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none sm:text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400"
+        />
+        <p className="mt-2 text-sm text-red-500 dark:text-red-400">
+          Warning: Changing the slug will break your current group URL and any
+          bookmarks to it that members may have.
+        </p>
+      </div>
+      <div>
+        <label
+          htmlFor="description"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Description
+        </label>
+        <textarea
+          id="description"
+          name="description"
+          defaultValue={group.description || ''}
+          rows={3}
+          className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none sm:text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400"
+        ></textarea>
+      </div>
+      <div>
+        <label
+          htmlFor="address"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Address
+        </label>
+        <input
+          type="text"
+          id="address"
+          name="address"
+          defaultValue={group.address || ''}
+          className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none sm:text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400"
+        />
+      </div>
+      <div>
+        <label
+          htmlFor="phone"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Phone
+        </label>
+        <input
+          type="text"
+          id="phone"
+          name="phone"
+          defaultValue={group.phone || ''}
+          className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none sm:text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400"
+        />
+      </div>
+      <div>
+        <label
+          htmlFor="logo"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Logo
+        </label>
+        <div className="mt-2 mb-4">
+          <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
+            Logo Preview:
+          </p>
+          <Image
+            src={previewUrl || logoUrl || '/images/default-avatar.png'}
+            alt={`${group.name} logo`}
+            width={300}
+            height={300}
+            className="rounded-md object-cover"
+          />
+        </div>
+        <input
+          type="file"
+          id="logo"
+          name="logo"
+          onChange={handleFileChange}
+          className="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:rounded-full file:border-0 file:bg-indigo-50 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-indigo-600 hover:file:bg-indigo-100 dark:text-gray-400 dark:file:bg-indigo-700 dark:file:text-indigo-200 dark:hover:file:bg-indigo-600"
+        />
+      </div>
+      <button
+        type="submit"
+        className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:outline-none dark:focus:ring-offset-gray-800"
+      >
+        Update Group
+      </button>
+    </form>
+  )
+}

--- a/src/app/g/[slug]/admin/group-admin-nav.tsx
+++ b/src/app/g/[slug]/admin/group-admin-nav.tsx
@@ -26,7 +26,9 @@ export default function GroupAdminNav({ slug }: GroupAdminNavProps) {
           <Link
             key={tab.name}
             href={tab.href}
-            className={`${tabBaseClasses} ${pathname === tab.href ? activeTabClasses : inactiveTabClasses}`}
+            className={`${tabBaseClasses} ${
+              pathname === tab.href ? activeTabClasses : inactiveTabClasses
+            }`}
           >
             {tab.name}
           </Link>

--- a/src/app/g/[slug]/admin/group-admin-nav.tsx
+++ b/src/app/g/[slug]/admin/group-admin-nav.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+interface GroupAdminNavProps {
+  slug: string;
+}
+
+export default function GroupAdminNav({ slug }: GroupAdminNavProps) {
+  const pathname = usePathname();
+
+  const tabs = [
+    { name: 'Group', href: `/g/${slug}/admin` },
+    { name: 'Members', href: `/g/${slug}/admin/members` },
+  ];
+
+  const tabBaseClasses = 'whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm';
+  const activeTabClasses = 'border-indigo-500 text-indigo-600';
+  const inactiveTabClasses = 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300';
+
+  return (
+    <div className="border-b border-gray-200 dark:border-gray-700">
+      <nav className="-mb-px flex space-x-8" aria-label="Tabs">
+        {tabs.map((tab) => (
+          <Link
+            key={tab.name}
+            href={tab.href}
+            className={`${tabBaseClasses} ${pathname === tab.href ? activeTabClasses : inactiveTabClasses}`}
+          >
+            {tab.name}
+          </Link>
+        ))}
+      </nav>
+    </div>
+  );
+}

--- a/src/app/g/[slug]/admin/layout.tsx
+++ b/src/app/g/[slug]/admin/layout.tsx
@@ -1,0 +1,48 @@
+import { redirect } from 'next/navigation'
+import { auth } from '@/auth'
+import { isAdmin } from '@/lib/auth-utils'
+import prisma from '@/lib/prisma'
+import { notFound } from 'next/navigation'
+import GroupAdminNav from './group-admin-nav'
+
+export default async function GroupAdminLayout({
+  children,
+  params: paramsPromise,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ slug: string }>;
+}) {
+  const params = await paramsPromise;
+  const { slug } = params;
+  const session = await auth();
+  const user = session?.user;
+
+  // 1. Check if user is logged in
+  if (!user) {
+    redirect(`/login?callbackUrl=/g/${slug}/admin`)
+  }
+
+  const group = await prisma.group.findUnique({
+    where: { slug },
+    select: { id: true },
+  })
+
+  if (!group) {
+    notFound()
+  }
+
+  // 2. Check if user has the 'admin' role in the group
+  const isGroupAdmin = await isAdmin(user.id, group.id)
+
+  if (!isGroupAdmin) {
+    // Redirect to group page if not a group admin
+    redirect(`/g/${slug}`)
+  }
+
+  return (
+    <div>
+      <GroupAdminNav slug={slug} />
+      <div className="mx-auto mt-6 max-w-4xl">{children}</div>
+    </div>
+  )
+}

--- a/src/app/g/[slug]/admin/layout.tsx
+++ b/src/app/g/[slug]/admin/layout.tsx
@@ -40,9 +40,9 @@ export default async function GroupAdminLayout({
   }
 
   return (
-    <div>
+    <div className="mx-auto mt-6 max-w-4xl px-4 sm:px-6 lg:px-8">
       <GroupAdminNav slug={slug} />
-      <div className="mx-auto mt-6 max-w-4xl">{children}</div>
+      {children}
     </div>
   )
 }

--- a/src/app/g/[slug]/admin/members/Search.tsx
+++ b/src/app/g/[slug]/admin/members/Search.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useSearchParams, usePathname, useRouter } from 'next/navigation';
+import { useDebouncedCallback } from 'use-debounce';
+
+export function Search({ placeholder }: { placeholder: string }) {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const { replace } = useRouter();
+
+  const handleSearch = useDebouncedCallback((term: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (term) {
+      params.set('query', term);
+    } else {
+      params.delete('query');
+    }
+    replace(`${pathname}?${params.toString()}`);
+  }, 300);
+
+  return (
+    <div className="relative flex flex-1 flex-shrink-0">
+      <label htmlFor="search" className="sr-only">
+        Search
+      </label>
+      <input
+        className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 pr-10 text-sm text-gray-900 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+        placeholder={placeholder}
+        onChange={(e) => {
+          handleSearch(e.target.value);
+        }}
+        defaultValue={searchParams.get('query')?.toString()}
+      />
+    </div>
+  );
+}

--- a/src/app/g/[slug]/admin/members/[userId]/edit/actions.ts
+++ b/src/app/g/[slug]/admin/members/[userId]/edit/actions.ts
@@ -1,0 +1,46 @@
+'use server';
+
+import { auth } from '@/auth';
+import prisma from '@/lib/prisma';
+import { Prisma } from '@prisma/client';
+import { isAdmin } from '@/lib/auth-utils';
+import { revalidatePath } from 'next/cache';
+
+interface UpdateMemberPayload {
+  userId: string;
+  groupId: number;
+  roleId: number;
+}
+
+export async function updateMemberRole({ userId, groupId, roleId }: UpdateMemberPayload, groupSlug: string) {
+  const session = await auth();
+  if (!session?.user) {
+    throw new Error('Authentication required');
+  }
+
+  // Authorize: check if the current user is an admin of the group
+  if (!(await isAdmin(session.user.id, groupId))) {
+    throw new Error('You do not have permission to edit members in this group.');
+  }
+
+  try {
+    // Update the user's role in the group
+    await prisma.groupUser.update({
+      where: {
+        userId_groupId: {
+          userId: userId,
+          groupId: groupId,
+        },
+      },
+      data: {
+        roleId: roleId,
+      },
+    });
+  } catch (error) {
+    console.error('Database Error:', error);
+    throw new Error('Failed to update member roles.');
+  }
+
+  revalidatePath(`/g/${groupSlug}/admin/members`);
+  revalidatePath(`/g/${groupSlug}/admin/members/${userId}/edit`);
+}

--- a/src/app/g/[slug]/admin/members/[userId]/edit/edit-member-form.tsx
+++ b/src/app/g/[slug]/admin/members/[userId]/edit/edit-member-form.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useTransition } from 'react';
+import type { GroupUser, GroupUserRole, User } from '@/generated/prisma';
+import { updateMemberRole } from './actions';
+
+// The member prop is a GroupUser object with the user and role relations included.
+interface EditMemberFormProps {
+  member: GroupUser & { user: User; role: GroupUserRole };
+  allRoles: GroupUserRole[];
+  groupSlug: string;
+}
+
+export default function EditMemberForm({ member, allRoles, groupSlug }: EditMemberFormProps) {
+  const [isPending, startTransition] = useTransition();
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const roleId = parseInt(formData.get('roleId') as string, 10);
+
+    if (isNaN(roleId)) {
+      alert('Please select a valid role.');
+      return;
+    }
+
+    startTransition(async () => {
+      try {
+        await updateMemberRole(
+          {
+            userId: member.userId,
+            groupId: member.groupId,
+            roleId: roleId,
+          },
+          groupSlug
+        );
+        alert('Role updated successfully!');
+      } catch (error) {
+        console.error('Failed to update role:', error);
+        alert('An error occurred while updating the role.');
+      }
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-8">
+      <div>
+        <h2 className="text-xl font-semibold">{`${member.user.firstName} ${member.user.lastName}`}</h2>
+        <p className="text-gray-500 dark:text-gray-400">{member.user.email}</p>
+      </div>
+
+      <div>
+        <label htmlFor="role" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+          Role
+        </label>
+        <select
+          id="role"
+          name="roleId"
+          defaultValue={member.roleId}
+          className="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white"
+        >
+          {allRoles.map(role => (
+            <option key={role.id} value={role.id}>
+              {role.code}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <button
+        type="submit"
+        disabled={isPending}
+        className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+      >
+        {isPending ? 'Saving...' : 'Save Changes'}
+      </button>
+    </form>
+  );
+}

--- a/src/app/g/[slug]/admin/members/actions.ts
+++ b/src/app/g/[slug]/admin/members/actions.ts
@@ -1,0 +1,38 @@
+'use server';
+
+import prisma from '@/lib/prisma';
+import { revalidatePath } from 'next/cache';
+import { isAdmin } from '@/lib/auth-utils';
+import { auth } from '@/auth';
+
+export async function removeMember({ userId, groupId }: { userId: string, groupId: number }, groupSlug: string) {
+  const session = await auth();
+  const user = session?.user;
+
+  if (!user) {
+    throw new Error('You must be logged in to perform this action.');
+  }
+
+  const group = await prisma.group.findUnique({
+    where: { slug: groupSlug },
+  });
+
+  if (!group) {
+    throw new Error('Group not found.');
+  }
+
+  if (!(await isAdmin(user.id, group.id))) {
+    throw new Error('You do not have permission to perform this action.');
+  }
+
+  try {
+        await prisma.groupUser.delete({
+      where: { userId_groupId: { userId, groupId } },
+    });
+  } catch (error) {
+    console.error('Database Error:', error);
+    throw new Error('Failed to remove member.');
+  }
+
+  revalidatePath(`/g/${groupSlug}/admin/members`);
+}

--- a/src/app/g/[slug]/admin/members/members-table.tsx
+++ b/src/app/g/[slug]/admin/members/members-table.tsx
@@ -56,7 +56,9 @@ export default function MembersTable({
                           <Image
                             className="h-10 w-10 rounded-full"
                             src={groupUser.user.photoUrl}
-                            alt=""
+                            alt={`${[groupUser.user.firstName, groupUser.user.lastName]
+                              .filter(Boolean)
+                              .join(' ')}'s photo`}
                             width={40}
                             height={40}
                           />

--- a/src/app/g/[slug]/admin/members/members-table.tsx
+++ b/src/app/g/[slug]/admin/members/members-table.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import type { GroupUser, GroupUserRole, User } from '@/generated/prisma'
+import Image from 'next/image'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import RemoveMemberButton from './remove-member-button'
+
+type GroupUserWithRelations = GroupUser & {
+  user: User & { photoUrl: string }
+  role: GroupUserRole
+}
+
+export default function MembersTable({
+  groupUsers,
+}: {
+  groupUsers: GroupUserWithRelations[]
+}) {
+  const params = useParams()
+  const slug = params.slug as string
+
+  return (
+    <div>
+      <div className="mt-8 flow-root">
+        <div className="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+          <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+            <table className="min-w-full table-fixed divide-y divide-gray-300 dark:divide-gray-700">
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                    className="w-1/2 px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white"
+                  >
+                    Name
+                  </th>
+                  <th
+                    scope="col"
+                    className="w-1/4 px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white"
+                  >
+                    Roles
+                  </th>
+                  <th
+                    scope="col"
+                    className="relative w-1/4 py-3.5 pr-4 pl-3 sm:pr-0"
+                  >
+                    <span className="sr-only">Edit</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+                {groupUsers.map((groupUser) => (
+                  <tr key={groupUser.userId}>
+                    <td className="py-4 pr-3 pl-4 text-sm break-all sm:pl-0">
+                      <div className="flex items-center">
+                        <div className="h-10 w-10 flex-shrink-0">
+                          <Image
+                            className="h-10 w-10 rounded-full"
+                            src={groupUser.user.photoUrl}
+                            alt=""
+                            width={40}
+                            height={40}
+                          />
+                        </div>
+                        <div className="ml-4">
+                          <div className="font-medium text-gray-900 dark:text-white">
+                            {[groupUser.user.firstName, groupUser.user.lastName]
+                              .filter(Boolean)
+                              .join(' ')}
+                          </div>
+                          <div className="text-gray-500 dark:text-gray-400">
+                            {groupUser.user.email}
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-3 py-4 text-sm text-gray-500">
+                      {groupUser.role.code}
+                    </td>
+                    <td className="relative py-4 pr-4 pl-3 text-right text-sm font-medium sm:pr-0">
+                      <Link
+                        href={`/g/${slug}/admin/members/${groupUser.userId}/edit`}
+                        className="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-200"
+                      >
+                        Edit
+                      </Link>
+                      <span className="mx-2 text-gray-300 dark:text-gray-600">
+                        |
+                      </span>
+                      <RemoveMemberButton
+                        userId={groupUser.userId}
+                        groupId={groupUser.groupId}
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/g/[slug]/admin/members/page.tsx
+++ b/src/app/g/[slug]/admin/members/page.tsx
@@ -1,16 +1,16 @@
-import prisma from '@/lib/prisma';
-import { notFound } from 'next/navigation';
-import { Search } from './Search';
-import MembersTable from './members-table';
-import { getPublicUrl } from '@/lib/storage';
+import prisma from '@/lib/prisma'
+import { notFound } from 'next/navigation'
+import { Search } from './Search'
+import MembersTable from './members-table'
+import { getPublicUrl } from '@/lib/storage'
 
 export default async function GroupMembersPage(props: {
-  params: Promise<{ slug: string }>;
-  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+  params: Promise<{ slug: string }>
+  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>
 }) {
-  const { slug } = await props.params;
-  const searchParams = await props.searchParams;
-  const searchTerm = (searchParams?.query as string) || '';
+  const { slug } = await props.params
+  const searchParams = await props.searchParams
+  const searchTerm = (searchParams?.query as string) || ''
 
   const group = await prisma.group.findUnique({
     where: { slug },
@@ -57,9 +57,9 @@ export default async function GroupMembersPage(props: {
     notFound()
   }
 
-  const groupUsers = group.members;
+  const groupUsers = group.members
 
-  const userIds = groupUsers.map(gu => gu.userId);
+  const userIds = groupUsers.map((gu) => gu.userId)
   const photos = await prisma.photo.findMany({
     where: {
       entityId: { in: userIds },
@@ -70,28 +70,28 @@ export default async function GroupMembersPage(props: {
       entityId: true,
       url: true,
     },
-  });
+  })
 
-  const photoUrlMap = new Map<string, string>();
+  const photoUrlMap = new Map<string, string>()
   for (const photo of photos) {
     if (photo.entityId) {
-      photoUrlMap.set(photo.entityId, photo.url);
+      photoUrlMap.set(photo.entityId, photo.url)
     }
   }
 
   const membersWithPhoto = await Promise.all(
-    groupUsers.map(async member => {
-      const rawUrl = photoUrlMap.get(member.userId);
-      let photoUrl: string;
+    groupUsers.map(async (member) => {
+      const rawUrl = photoUrlMap.get(member.userId)
+      let photoUrl: string
       if (rawUrl) {
         if (rawUrl.startsWith('http')) {
-          photoUrl = rawUrl;
+          photoUrl = rawUrl
         } else {
-          photoUrl = await getPublicUrl(rawUrl);
+          photoUrl = await getPublicUrl(rawUrl)
         }
       } else {
-        // Fallback to a default avatar service
-        photoUrl = `https://api.dicebear.com/8.x/personas/png?seed=${member.user.id}`;
+        // Fallback to the default avatar
+        photoUrl = '/images/default-avatar.png'
       }
       return {
         ...member,
@@ -99,10 +99,9 @@ export default async function GroupMembersPage(props: {
           ...member.user,
           photoUrl,
         },
-      };
+      }
     }),
-  );
-
+  )
 
   return (
     <div className="p-8">
@@ -114,5 +113,5 @@ export default async function GroupMembersPage(props: {
         <MembersTable groupUsers={membersWithPhoto} />
       </div>
     </div>
-  );
+  )
 }

--- a/src/app/g/[slug]/admin/members/page.tsx
+++ b/src/app/g/[slug]/admin/members/page.tsx
@@ -1,0 +1,118 @@
+import prisma from '@/lib/prisma';
+import { notFound } from 'next/navigation';
+import { Search } from './Search';
+import MembersTable from './members-table';
+import { getPublicUrl } from '@/lib/storage';
+
+export default async function GroupMembersPage(props: {
+  params: Promise<{ slug: string }>;
+  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const { slug } = await props.params;
+  const searchParams = await props.searchParams;
+  const searchTerm = (searchParams?.query as string) || '';
+
+  const group = await prisma.group.findUnique({
+    where: { slug },
+    include: {
+      members: {
+        where: {
+          user: {
+            OR: [
+              {
+                firstName: {
+                  contains: searchTerm,
+                  mode: 'insensitive',
+                },
+              },
+              {
+                lastName: {
+                  contains: searchTerm,
+                  mode: 'insensitive',
+                },
+              },
+              {
+                email: {
+                  contains: searchTerm,
+                  mode: 'insensitive',
+                },
+              },
+            ],
+          },
+        },
+        include: {
+          user: true,
+          role: true, // Each GroupUser has one role
+        },
+        orderBy: {
+          user: {
+            username: 'asc',
+          },
+        },
+      },
+    },
+  })
+
+  if (!group) {
+    notFound()
+  }
+
+  const groupUsers = group.members;
+
+  const userIds = groupUsers.map(gu => gu.userId);
+  const photos = await prisma.photo.findMany({
+    where: {
+      entityId: { in: userIds },
+      // Assuming you have a way to identify primary photos, e.g., a specific photoTypeId or a flag
+      // This part might need adjustment based on your exact schema for primary photos
+    },
+    select: {
+      entityId: true,
+      url: true,
+    },
+  });
+
+  const photoUrlMap = new Map<string, string>();
+  for (const photo of photos) {
+    if (photo.entityId) {
+      photoUrlMap.set(photo.entityId, photo.url);
+    }
+  }
+
+  const membersWithPhoto = await Promise.all(
+    groupUsers.map(async member => {
+      const rawUrl = photoUrlMap.get(member.userId);
+      let photoUrl: string;
+      if (rawUrl) {
+        if (rawUrl.startsWith('http')) {
+          photoUrl = rawUrl;
+        } else {
+          photoUrl = await getPublicUrl(rawUrl);
+        }
+      } else {
+        // Fallback to a default avatar service
+        photoUrl = `https://api.dicebear.com/8.x/personas/png?seed=${member.user.id}`;
+      }
+      return {
+        ...member,
+        user: {
+          ...member.user,
+          photoUrl,
+        },
+      };
+    }),
+  );
+
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold">Members</h1>
+      <div className="mt-4">
+        <Search placeholder="Search members..." />
+      </div>
+      <div className="mt-8">
+        <MembersTable groupUsers={membersWithPhoto} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/g/[slug]/admin/members/remove-member-button.tsx
+++ b/src/app/g/[slug]/admin/members/remove-member-button.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { removeMember } from './actions';
+import { useState, useTransition } from 'react';
+import { useParams } from 'next/navigation';
+
+export default function RemoveMemberButton({ userId, groupId }: { userId: string, groupId: number }) {
+  const [isPending, startTransition] = useTransition();
+  const [showModal, setShowModal] = useState(false);
+  const params = useParams();
+  const slug = params.slug as string;
+
+  const handleRemove = () => {
+    startTransition(async () => {
+      try {
+        await removeMember({ userId, groupId }, slug);
+        // In a real app, you'd use a toast notification for success
+      } catch (error) {
+        // In a real app, you'd use a toast notification for error
+        alert(error instanceof Error ? error.message : 'An unknown error occurred');
+      }
+      setShowModal(false);
+    });
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setShowModal(true)}
+        disabled={isPending}
+        className="font-medium text-red-600 hover:text-red-900 disabled:text-gray-400 dark:text-red-500 dark:hover:text-red-400 dark:disabled:text-gray-500"
+      >
+        Remove
+      </button>
+
+      {showModal && (
+        <div className="fixed inset-0 bg-black/25 backdrop-blur-sm flex justify-center items-center z-50">
+          <div className="bg-white p-6 rounded-lg shadow-xl w-full max-w-md dark:bg-gray-800">
+            <h3 className="text-lg font-bold mb-4 dark:text-white">Remove Member</h3>
+            <p className="mb-6 text-wrap text-left dark:text-gray-300">Are you sure you want to remove this member from the group? This action cannot be undone.</p>
+            <div className="flex justify-end gap-4">
+              <button
+                type="button"
+                onClick={() => setShowModal(false)}
+                className="px-4 py-2 rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-600 dark:hover:bg-gray-600"
+                disabled={isPending}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleRemove}
+                disabled={isPending}
+                className="px-4 py-2 rounded-md border border-transparent bg-red-600 text-white hover:bg-red-700 disabled:bg-red-400"
+              >
+                {isPending ? 'Removing...' : 'Remove'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/g/[slug]/admin/page.tsx
+++ b/src/app/g/[slug]/admin/page.tsx
@@ -1,0 +1,40 @@
+import prisma from '@/lib/prisma';
+import { notFound } from 'next/navigation';
+import { getPublicUrl } from '@/lib/storage';
+import EditGroupForm from './edit-group-form';
+import { getCodeTable } from '@/lib/codes';
+
+export default async function GroupAdminSettingsPage(props: { params: Promise<{ slug: string }> }) {
+  const params = await props.params;
+  const { slug } = params;
+
+  const [entityTypes, photoTypes] = await Promise.all([
+    getCodeTable('entityType'),
+    getCodeTable('photoType'),
+  ]);
+
+  const group = await prisma.group.findUnique({
+    where: {
+      slug: slug,
+    },
+  });
+
+  if (!group) {
+    notFound();
+  }
+
+  const logo = await prisma.photo.findFirst({
+    where: {
+      entityId: group.id.toString(),
+      entityTypeId: entityTypes.group.id,
+      typeId: photoTypes.logo.id,
+    },
+  });
+  const logoUrl = await getPublicUrl(logo?.url);
+
+  return (
+    <div className="p-8">
+      <EditGroupForm group={group} logoUrl={logoUrl} />
+    </div>
+  );
+}

--- a/src/app/g/[slug]/all/data.ts
+++ b/src/app/g/[slug]/all/data.ts
@@ -63,14 +63,14 @@ export const getGroup = async (
     prisma.photoType.findFirst({ where: { code: 'logo' } }),
   ]);
 
-  const logo = await prisma.photo.findFirst({
+  const logoPhoto = await prisma.photo.findFirst({
     where: {
       entityId: group.id.toString(),
       entityTypeId: groupEntityType?.id,
       typeId: logoPhotoType?.id,
     },
   });
-  const logoUrl = logo?.url ? await getPublicUrl(logo.url) : undefined;
+  const logo = logoPhoto?.url ? await getPublicUrl(logoPhoto.url) : undefined;
 
   const memberUserIds = group.members.map((member) => member.userId)
   const photos = await prisma.photo.findMany({
@@ -202,7 +202,7 @@ export const getGroup = async (
 
   return {
     ...group,
-    logoUrl,
+    logo,
     isSuperAdmin: !!superAdminMembership,
     sunDeckMembers: limitedSunDeckMembers,
     iceBlockMembers: limitedIceBlockMembers,

--- a/src/app/g/[slug]/all/data.ts
+++ b/src/app/g/[slug]/all/data.ts
@@ -56,10 +56,21 @@ export const getGroup = async (
   }
 
   // Fetch code table IDs for photo types
-  const [userEntityType, primaryPhotoType] = await Promise.all([
+  const [userEntityType, primaryPhotoType, groupEntityType, logoPhotoType] = await Promise.all([
     prisma.entityType.findFirst({ where: { code: 'user' } }),
     prisma.photoType.findFirst({ where: { code: 'primary' } }),
-  ])
+    prisma.entityType.findFirst({ where: { code: 'group' } }),
+    prisma.photoType.findFirst({ where: { code: 'logo' } }),
+  ]);
+
+  const logo = await prisma.photo.findFirst({
+    where: {
+      entityId: group.id.toString(),
+      entityTypeId: groupEntityType?.id,
+      typeId: logoPhotoType?.id,
+    },
+  });
+  const logoUrl = logo?.url ? await getPublicUrl(logo.url) : undefined;
 
   const memberUserIds = group.members.map((member) => member.userId)
   const photos = await prisma.photo.findMany({
@@ -191,6 +202,7 @@ export const getGroup = async (
 
   return {
     ...group,
+    logoUrl,
     isSuperAdmin: !!superAdminMembership,
     sunDeckMembers: limitedSunDeckMembers,
     iceBlockMembers: limitedIceBlockMembers,

--- a/src/app/g/[slug]/family/data.ts
+++ b/src/app/g/[slug]/family/data.ts
@@ -54,10 +54,21 @@ export const getGroup = async (slug: string, limit?: number): Promise<FamilyGrou
   }
 
   // Fetch code table IDs for photo types
-  const [userEntityType, primaryPhotoType] = await Promise.all([
+  const [userEntityType, primaryPhotoType, groupEntityType, logoPhotoType] = await Promise.all([
     prisma.entityType.findFirst({ where: { code: 'user' } }),
     prisma.photoType.findFirst({ where: { code: 'primary' } }),
+    prisma.entityType.findFirst({ where: { code: 'group' } }),
+    prisma.photoType.findFirst({ where: { code: 'logo' } }),
   ]);
+
+  const logo = await prisma.photo.findFirst({
+    where: {
+      entityId: group.id.toString(),
+      entityTypeId: groupEntityType?.id,
+      typeId: logoPhotoType?.id,
+    },
+  });
+  const logoUrl = logo?.url ? await getPublicUrl(logo.url) : undefined;
 
   const memberUserIds = group.members.map((member) => member.userId);
   const photos = await prisma.photo.findMany({
@@ -119,6 +130,7 @@ export const getGroup = async (slug: string, limit?: number): Promise<FamilyGrou
 
   return {
     ...group,
+    logoUrl,
     isSuperAdmin: !!superAdminMembership,
     members: limitedMembers,
     memberCount: allMembers.length,

--- a/src/app/g/[slug]/family/data.ts
+++ b/src/app/g/[slug]/family/data.ts
@@ -61,14 +61,14 @@ export const getGroup = async (slug: string, limit?: number): Promise<FamilyGrou
     prisma.photoType.findFirst({ where: { code: 'logo' } }),
   ]);
 
-  const logo = await prisma.photo.findFirst({
+  const logoPhoto = await prisma.photo.findFirst({
     where: {
       entityId: group.id.toString(),
       entityTypeId: groupEntityType?.id,
       typeId: logoPhotoType?.id,
     },
   });
-  const logoUrl = logo?.url ? await getPublicUrl(logo.url) : undefined;
+  const logo = logoPhoto?.url ? await getPublicUrl(logoPhoto.url) : undefined;
 
   const memberUserIds = group.members.map((member) => member.userId);
   const photos = await prisma.photo.findMany({
@@ -130,7 +130,7 @@ export const getGroup = async (slug: string, limit?: number): Promise<FamilyGrou
 
   return {
     ...group,
-    logoUrl,
+    logo,
     isSuperAdmin: !!superAdminMembership,
     members: limitedMembers,
     memberCount: allMembers.length,

--- a/src/app/g/[slug]/family/page.tsx
+++ b/src/app/g/[slug]/family/page.tsx
@@ -1,6 +1,7 @@
 import { getGroup } from './data';
 import { FamilyGroupClient } from './FamilyGroupClient';
 import { notFound } from 'next/navigation';
+import { getPublicUrl } from '@/lib/storage';
 
 // This will be the custom page for family groups.
 // For now, it's a simple placeholder.
@@ -12,9 +13,23 @@ export default async function FamilyGroupPage({ params }: { params: Promise<{ sl
     notFound();
   }
 
+  // Enhance members with pre-signed photo URLs
+  const membersWithPhotoUrls = await Promise.all(
+    group.members.map(async (member) => {
+      const photoUrl = await getPublicUrl(member.user.photoUrl);
+      return {
+        ...member,
+        user: {
+          ...member.user,
+          photoUrl: photoUrl,
+        },
+      };
+    }),
+  );
+
   return (
     <FamilyGroupClient
-      initialMembers={group.members}
+      initialMembers={membersWithPhotoUrls}
       groupSlug={slug}
       initialMemberCount={group.memberCount}
     />

--- a/src/app/g/[slug]/layout.tsx
+++ b/src/app/g/[slug]/layout.tsx
@@ -92,7 +92,11 @@ export default async function GroupLayout(props: { children: React.ReactNode; pa
       }}
     >
       <div className="relative flex min-h-screen flex-col">
-        <Header />
+        <Header 
+          group={groupForProvider}
+          isGroupAdmin={currentUserMember?.role.code === 'admin'}
+          groupSlug={slug}
+        />
         <main className="main-container flex-grow pb-24">
           {children}
         </main>

--- a/src/components/FamilyMemberCard.tsx
+++ b/src/components/FamilyMemberCard.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import Image from 'next/image'
 import type { MemberWithUser as Member } from '@/types/index'
 import { formatDistanceToNow } from 'date-fns'
@@ -22,6 +20,7 @@ export default function FamilyMemberCard({
   relationship,
 }: FamilyMemberCardProps) {
   const isListView = viewMode === 'list'
+  const imageUrl = member.user.photoUrl || '/images/default-avatar.png'
 
   return (
     <div
@@ -34,14 +33,19 @@ export default function FamilyMemberCard({
       <div
         className={
           isListView
-            ? 'relative h-24 w-24 flex-shrink-0'
+            ? 'relative h-36 w-36 flex-shrink-0'
             : 'border-border relative aspect-square w-full overflow-hidden rounded-md border shadow-lg dark:shadow-lg dark:shadow-white/10'
         }
       >
         <Image
-          src={member.user.photoUrl || '/images/default-avatar.png'}
+          src={imageUrl}
           alt={member.user.name || 'User avatar'}
           fill
+          sizes={
+            isListView
+              ? '96px'
+              : '(max-width: 767px) 100vw, (max-width: 1023px) 50vw, 33vw'
+          }
           className="rounded object-cover p-4"
         />
       </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,60 +1,70 @@
-'use client';
+'use client'
 
-import { useState } from 'react';
-import { useGroup } from './GroupProvider';
-import { createGreetingCode } from '@/app/greet/[code]/actions';
-import QRCodeModal from './QRCodeModal';
-import { Button } from './ui/button';
-import { PlusIcon } from 'lucide-react';
+import { useState } from 'react'
+import { useGroup } from './GroupProvider'
+import { createGreetingCode } from '@/app/greet/[code]/actions'
+import QRCodeModal from './QRCodeModal'
+import { Button } from './ui/button'
+import { PlusIcon } from 'lucide-react'
 
 export default function Footer() {
-  const { group, isAuthorizedMember } = useGroup();
-  const [isLoading, setIsLoading] = useState(false);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [greetingUrl, setGreetingUrl] = useState('');
+  const { group, isAuthorizedMember } = useGroup()
+  const [isLoading, setIsLoading] = useState(false)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [greetingUrl, setGreetingUrl] = useState('')
 
   if (!group || isAuthorizedMember !== true) {
     return (
-      <footer className="fixed bottom-0 left-0 w-full h-16 bg-background text-center py-4 shadow-[0_-2px_4px_rgba(0,0,0,0.1)] dark:shadow-[0_-2px_4px_rgba(255,255,255,0.1)]">
+      <footer className="bg-background fixed bottom-0 left-0 h-16 w-full py-4 text-center shadow-[0_-2px_4px_rgba(0,0,0,0.1)] dark:shadow-[0_-2px_4px_rgba(255,255,255,0.1)]">
         <p className="text-gray-600 dark:text-gray-400">&copy; 2025 NameGame</p>
       </footer>
-    );
+    )
   }
 
   const handleClick = async () => {
-    if (!group) return;
+    if (!group) return
 
-    setIsLoading(true);
+    setIsLoading(true)
     try {
-      const newCode = await createGreetingCode(group.id);
-      const url = `${window.location.origin}/greet/${newCode.code}`;
-      setGreetingUrl(url);
-      setIsModalOpen(true);
+      const newCode = await createGreetingCode(group.id)
+      const url = `${window.location.origin}/greet/${newCode.code}`
+      setGreetingUrl(url)
+      setIsModalOpen(true)
     } catch (error) {
-      console.error('Failed to create greeting code:', error);
-      alert('Failed to create greeting code. Please try again.');
+      console.error('Failed to create greeting code:', error)
+      alert('Failed to create greeting code. Please try again.')
     } finally {
-      setIsLoading(false);
+      setIsLoading(false)
     }
-  };
+  }
 
   const handleCloseModal = () => {
-    setIsModalOpen(false);
-    setGreetingUrl('');
-  };
+    setIsModalOpen(false)
+    setGreetingUrl('')
+  }
 
-  const isFamilyGroup = group.groupType?.code === 'family';
-  const buttonText = isFamilyGroup ? 'Invite' : 'Greet';
+  const isFamilyGroup = group.groupType?.code === 'family'
+  const buttonText = isFamilyGroup ? 'Invite' : 'Greet'
 
   return (
     <>
-      <footer className="fixed bottom-0 left-0 w-full h-20 bg-background text-center py-4 shadow-[0_-2px_4px_rgba(0,0,0,0.1)] dark:shadow-[0_-2px_4px_rgba(255,255,255,0.1)] flex justify-center items-center">
-        <Button size='lg' className='h-12' onClick={handleClick} disabled={isLoading}>
-          <PlusIcon className='mr-2 h-6 w-6' />
+      <footer className="bg-background fixed bottom-0 left-0 flex h-16 w-full items-center justify-center py-4 text-center shadow-[0_-2px_4px_rgba(0,0,0,0.1)] dark:shadow-[0_-2px_4px_rgba(255,255,255,0.1)]">
+        <Button
+          size="sm"
+          className="h-10"
+          onClick={handleClick}
+          disabled={isLoading}
+        >
+          <PlusIcon className="mr-2 h-6 w-6" />
           {isLoading ? 'Generating...' : buttonText}
         </Button>
       </footer>
-      <QRCodeModal isOpen={isModalOpen} url={greetingUrl} onClose={handleCloseModal} isFamilyGroup={isFamilyGroup} />
+      <QRCodeModal
+        isOpen={isModalOpen}
+        url={greetingUrl}
+        onClose={handleCloseModal}
+        isFamilyGroup={isFamilyGroup}
+      />
     </>
-  );
+  )
 }

--- a/src/components/GroupInfoModal.tsx
+++ b/src/components/GroupInfoModal.tsx
@@ -5,6 +5,7 @@ import { GroupData } from '@/types'
 import { getGroupAdmins } from '@/app/g/[slug]/admin/actions'
 import { User } from '@/generated/prisma'
 import { X } from 'lucide-react'
+import Image from 'next/image'
 
 interface GroupInfoModalProps {
   group: GroupData
@@ -50,11 +51,21 @@ export default function GroupInfoModal({
           <X size={24} />
         </button>
         <div className="p-6">
-          <h2 className="mb-4 text-2xl font-bold text-gray-800 dark:text-gray-100">
+          {group.logo && (
+            <div className="mb-4 flex justify-center">
+              <Image
+                src={group.logo}
+                alt={`${group.name} logo`}
+                width={128}
+                height={128}
+              />
+            </div>
+          )}
+          <h2 className="mb-4 text-center text-2xl font-bold text-gray-800 dark:text-gray-100">
             {group.name}
           </h2>
           {group.description && (
-            <p className="mb-4 text-gray-600 dark:text-gray-300">
+            <p className="mb-4 max-h-24 overflow-y-auto whitespace-pre-wrap text-gray-600 dark:text-gray-300">
               {group.description}
             </p>
           )}

--- a/src/components/GroupInfoModal.tsx
+++ b/src/components/GroupInfoModal.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { GroupData } from '@/types'
+import { getGroupAdmins } from '@/app/g/[slug]/admin/actions'
+import { User } from '@/generated/prisma'
+import { X } from 'lucide-react'
+
+interface GroupInfoModalProps {
+  group: GroupData
+  isOpen: boolean
+  onClose: () => void
+}
+
+export default function GroupInfoModal({
+  group,
+  isOpen,
+  onClose,
+}: GroupInfoModalProps) {
+  const [admins, setAdmins] = useState<User[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    if (isOpen) {
+      setIsLoading(true)
+      getGroupAdmins(group.id)
+        .then(setAdmins)
+        .catch(console.error)
+        .finally(() => setIsLoading(false))
+    }
+  }, [isOpen, group.id])
+
+  if (!isOpen) {
+    return null
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-md rounded-lg bg-white shadow-2xl dark:bg-gray-900"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          onClick={onClose}
+          className="absolute top-3 right-3 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+        >
+          <X size={24} />
+        </button>
+        <div className="p-6">
+          <h2 className="mb-4 text-2xl font-bold text-gray-800 dark:text-gray-100">
+            {group.name}
+          </h2>
+          {group.description && (
+            <p className="mb-4 text-gray-600 dark:text-gray-300">
+              {group.description}
+            </p>
+          )}
+          {group.address && (
+            <p className="mb-2 text-gray-600 dark:text-gray-300">
+              <strong>Address:</strong> {group.address}
+            </p>
+          )}
+          {group.phone && (
+            <p className="mb-4 text-gray-600 dark:text-gray-300">
+              <strong>Phone:</strong> {group.phone}
+            </p>
+          )}
+
+          <h3 className="mt-6 mb-2 text-lg font-semibold text-gray-700 dark:text-gray-200">
+            Admins
+          </h3>
+          {isLoading ? (
+            <p className="text-gray-500 dark:text-gray-400">
+              Loading admins...
+            </p>
+          ) : (
+            <ul className="list-inside list-disc text-gray-600 dark:text-gray-300">
+              {admins.map((admin) => (
+                <li key={admin.id}>
+                  {admin.firstName} {admin.lastName}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,12 +2,17 @@
 
 import Link from 'next/link';
 import UserMenu from './UserMenu';
-import { useGroup } from './GroupProvider';
 import Image from 'next/image';
+import { GroupData } from '@/types';
+import { Settings } from 'lucide-react';
 
-export default function Header() {
-  const { group } = useGroup();
+interface HeaderProps {
+  group?: GroupData | null;
+  isGroupAdmin?: boolean;
+  groupSlug?: string;
+}
 
+export default function Header({ group, isGroupAdmin, groupSlug }: HeaderProps) {
   return (
     <header className="bg-background border-b border-border sticky top-0 left-0 w-full z-50">
       <div className="container mx-auto flex justify-between items-center px-5 py-1 h-full">
@@ -30,7 +35,14 @@ export default function Header() {
             NameGame
           </Link>
         )}
-        <UserMenu />
+        <div className="flex items-center gap-4">
+          {isGroupAdmin && groupSlug && (
+            <Link href={`/g/${groupSlug}/admin`} className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-white">
+              <Settings size={24} />
+            </Link>
+          )}
+          <UserMenu />
+        </div>
       </div>
     </header>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,30 +1,45 @@
-'use client';
+'use client'
 
-import Link from 'next/link';
-import UserMenu from './UserMenu';
-import Image from 'next/image';
-import { GroupData } from '@/types';
-import { Settings } from 'lucide-react';
+import Link from 'next/link'
+import UserMenu from './UserMenu'
+import Image from 'next/image'
+import { GroupData } from '@/types'
+import { Settings } from 'lucide-react'
 
 interface HeaderProps {
-  group?: GroupData | null;
-  isGroupAdmin?: boolean;
-  groupSlug?: string;
+  group?: GroupData | null
+  isGroupAdmin?: boolean
+  groupSlug?: string
 }
 
-export default function Header({ group, isGroupAdmin, groupSlug }: HeaderProps) {
+export default function Header({
+  group,
+  isGroupAdmin,
+  groupSlug,
+}: HeaderProps) {
   return (
-    <header className="bg-background border-b border-border sticky top-0 left-0 w-full z-50">
-      <div className="container mx-auto flex justify-between items-center px-5 py-1 h-full">
+    <header className="bg-background border-border sticky top-0 left-0 z-50 w-full border-b">
+      <div className="container mx-auto flex h-full items-center justify-between px-5 py-1">
         {group ? (
-          <Link
-            href={`/g/${group.slug}`}
-            className="block truncate text-xl font-bold text-gray-600 dark:text-gray-200 max-w-[200px] sm:max-w-none"
-          >
-            {group.name}
+          <Link href={`/g/${group.slug}`} className="flex items-center gap-2">
+            {group.logoUrl && (
+              <Image
+                src={group.logoUrl}
+                alt={`${group.name} logo`}
+                width={32}
+                height={32}
+                className="h-10 w-10 object-cover"
+              />
+            )}
+            <span className="block max-w-[200px] truncate text-xl font-bold text-gray-600 sm:max-w-none dark:text-gray-200">
+              {group.name}
+            </span>
           </Link>
         ) : (
-          <Link href="/" className="text-xl font-bold text-gray-600 dark:text-gray-200 flex items-center">
+          <Link
+            href="/"
+            className="flex items-center text-xl font-bold text-gray-600 dark:text-gray-200"
+          >
             <Image
               src="/images/butterfly.png"
               alt="NameGame social butterfly"
@@ -37,7 +52,10 @@ export default function Header({ group, isGroupAdmin, groupSlug }: HeaderProps) 
         )}
         <div className="flex items-center gap-4">
           {isGroupAdmin && groupSlug && (
-            <Link href={`/g/${groupSlug}/admin`} className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-white">
+            <Link
+              href={`/g/${groupSlug}/admin`}
+              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-white"
+            >
               <Settings size={24} />
             </Link>
           )}
@@ -45,5 +63,5 @@ export default function Header({ group, isGroupAdmin, groupSlug }: HeaderProps) 
         </div>
       </div>
     </header>
-  );
+  )
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,12 @@
 'use client'
 
+import { useState } from 'react';
 import Link from 'next/link'
 import UserMenu from './UserMenu'
 import Image from 'next/image'
 import { GroupData } from '@/types'
 import { Settings } from 'lucide-react'
+import GroupInfoModal from './GroupInfoModal';
 
 interface HeaderProps {
   group?: GroupData | null
@@ -17,11 +19,14 @@ export default function Header({
   isGroupAdmin,
   groupSlug,
 }: HeaderProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   return (
-    <header className="bg-background border-border sticky top-0 left-0 z-50 w-full border-b">
-      <div className="container mx-auto flex h-full items-center justify-between px-5 py-1">
-        {group ? (
-          <Link href={`/g/${group.slug}`} className="flex items-center gap-2">
+    <>
+      <header className="bg-background border-border sticky top-0 left-0 z-50 w-full border-b">
+        <div className="container mx-auto flex h-full items-center justify-between px-5 py-1">
+          {group ? (
+            <button onClick={() => setIsModalOpen(true)} className="flex items-center gap-2 text-left">
             {group.logoUrl && (
               <Image
                 src={group.logoUrl}
@@ -34,7 +39,7 @@ export default function Header({
             <span className="block max-w-[200px] truncate text-xl font-bold text-gray-600 sm:max-w-none dark:text-gray-200">
               {group.name}
             </span>
-          </Link>
+          </button>
         ) : (
           <Link
             href="/"
@@ -63,5 +68,13 @@ export default function Header({
         </div>
       </div>
     </header>
+    {group && (
+      <GroupInfoModal 
+        group={group} 
+        isOpen={isModalOpen} 
+        onClose={() => setIsModalOpen(false)} 
+      />
+    )}
+    </>
   )
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -27,9 +27,9 @@ export default function Header({
         <div className="container mx-auto flex h-full items-center justify-between px-5 py-1">
           {group ? (
             <button onClick={() => setIsModalOpen(true)} className="flex items-center gap-2 text-left">
-            {group.logoUrl && (
+            {group.logo && (
               <Image
-                src={group.logoUrl}
+                src={group.logo}
                 alt={`${group.name} logo`}
                 width={32}
                 height={32}

--- a/src/components/MemberCard.tsx
+++ b/src/components/MemberCard.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Image from 'next/image';
 import type { MemberWithUser as Member } from '@/types/index';
 import { formatDistanceToNow } from 'date-fns';
@@ -9,6 +7,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { getPublicUrl } from '@/lib/storage';
 
 interface MemberCardProps {
   member: Member;
@@ -17,15 +16,17 @@ interface MemberCardProps {
   relationship?: string;
 }
 
-export default function MemberCard({ member, listType, viewMode, relationship }: MemberCardProps) {
+export default async function MemberCard({ member, listType, viewMode, relationship }: MemberCardProps) {
+  const imageUrl = await getPublicUrl(member.user.photoUrl);
   if (listType === 'sunDeck' && viewMode === 'list') {
     return (
       <div className="flex items-center space-x-4 p-2 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
         <div className="relative w-24 h-24 rounded overflow-hidden flex-shrink-0">
           <Image
-            src={member.user.photoUrl || '/images/default-avatar.png'}
+            src={imageUrl}
             alt={member.user.name || 'User avatar'}
             fill
+            sizes="96px"
             className="object-cover"
           />
         </div>
@@ -59,9 +60,10 @@ export default function MemberCard({ member, listType, viewMode, relationship }:
     <div className="text-center transition-transform duration-300 ease-in-out">
       <div className="relative w-full aspect-square rounded-lg overflow-hidden shadow-lg">
                 <Image
-          src={member.user.photoUrl || '/images/default-avatar.png'}
+          src={imageUrl}
           alt={member.user.name || 'User avatar'}
           fill
+          sizes="(max-width: 767px) 100vw, (max-width: 1023px) 50vw, 33vw"
           className={`object-cover`}
         />
       </div>

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -4,12 +4,13 @@ import { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { signOut, useSession } from 'next-auth/react';
-import { getPublicUrl } from '@/lib/storage-client';
+import { getSecureImageUrl } from '@/lib/actions';
 
 export default function UserMenu() {
   const { data: session, update } = useSession();
   const [isDropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const [imageUrl, setImageUrl] = useState('/images/default-avatar.png');
 
   // Listen for photo updates from other tabs/windows
   useEffect(() => {
@@ -40,6 +41,14 @@ export default function UserMenu() {
     };
   }, []);
 
+  useEffect(() => {
+    if (session?.user?.image) {
+      getSecureImageUrl(session.user.image).then(setImageUrl);
+    } else {
+      setImageUrl('/images/default-avatar.png');
+    }
+  }, [session?.user?.image]);
+
   const toggleDropdown = () => {
     setDropdownOpen(!isDropdownOpen);
   };
@@ -49,7 +58,6 @@ export default function UserMenu() {
   };
 
   const user = session?.user;
-  const imageUrl = getPublicUrl(user?.image);
   const isSuperAdmin = user?.isSuperAdmin;
 
   return (

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,29 +1,29 @@
-'use client';
+'use client'
 
-import { useState, useRef, useEffect } from 'react';
-import Image from 'next/image';
-import Link from 'next/link';
-import { signOut, useSession } from 'next-auth/react';
-import { getSecureImageUrl } from '@/lib/actions';
+import { useState, useRef, useEffect } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { signOut, useSession } from 'next-auth/react'
+import { getSecureImageUrl } from '@/lib/actions'
 
 export default function UserMenu() {
-  const { data: session, update } = useSession();
-  const [isDropdownOpen, setDropdownOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  const [imageUrl, setImageUrl] = useState('/images/default-avatar.png');
+  const { data: session, update } = useSession()
+  const [isDropdownOpen, setDropdownOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const [imageUrl, setImageUrl] = useState('/images/default-avatar.png')
 
   // Listen for photo updates from other tabs/windows
   useEffect(() => {
-    const channel = new BroadcastChannel('photo_updates');
+    const channel = new BroadcastChannel('photo_updates')
     const handlePhotoUpdate = () => {
-      update(); // Refetch the session
-    };
-    channel.addEventListener('message', handlePhotoUpdate);
+      update() // Refetch the session
+    }
+    channel.addEventListener('message', handlePhotoUpdate)
     return () => {
-      channel.removeEventListener('message', handlePhotoUpdate);
-      channel.close();
-    };
-  }, [update]);
+      channel.removeEventListener('message', handlePhotoUpdate)
+      channel.close()
+    }
+  }, [update])
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -31,50 +31,57 @@ export default function UserMenu() {
         dropdownRef.current &&
         !dropdownRef.current.contains(event.target as Node)
       ) {
-        setDropdownOpen(false);
+        setDropdownOpen(false)
       }
-    };
+    }
 
-    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('mousedown', handleClickOutside)
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, []);
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [])
 
   useEffect(() => {
     if (session?.user?.image) {
-      getSecureImageUrl(session.user.image).then(setImageUrl);
+      getSecureImageUrl(session.user.image).then(setImageUrl)
     } else {
-      setImageUrl('/images/default-avatar.png');
+      setImageUrl('/images/default-avatar.png')
     }
-  }, [session?.user?.image]);
+  }, [session?.user?.image])
 
   const toggleDropdown = () => {
-    setDropdownOpen(!isDropdownOpen);
-  };
+    setDropdownOpen(!isDropdownOpen)
+  }
 
   const closeDropdown = () => {
-    setDropdownOpen(false);
-  };
+    setDropdownOpen(false)
+  }
 
-  const user = session?.user;
-  const isSuperAdmin = user?.isSuperAdmin;
+  const user = session?.user
+  const isSuperAdmin = user?.isSuperAdmin
 
   return (
     <div className="relative" ref={dropdownRef}>
-      <button onClick={toggleDropdown} className="flex items-center py-2 px-4 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800">
-        {user && <p className="mr-4 text-gray-700 dark:text-gray-300 hidden sm:block">{user.firstName}</p>}
+      <button
+        onClick={toggleDropdown}
+        className="flex items-center rounded-lg py-2 pl-4 hover:bg-gray-100 dark:hover:bg-gray-800"
+      >
+        {user && (
+          <p className="mr-4 hidden text-gray-700 sm:block dark:text-gray-300">
+            {user.firstName}
+          </p>
+        )}
         <Image
           src={imageUrl}
           alt="User Profile"
           width={40}
           height={40}
-          className="w-10 h-10 rounded-full"
+          className="h-10 w-10 rounded-full"
           key={user?.image} // Add key to force re-render on image change
         />
       </button>
       {isDropdownOpen && (
-        <div className="absolute top-full mt-2 right-0 bg-white rounded-md shadow-lg py-2 z-50 w-48 dark:bg-gray-800">
+        <div className="absolute top-full right-0 z-50 mt-2 w-48 rounded-md bg-white py-2 shadow-lg dark:bg-gray-800">
           {user ? (
             <>
               <Link
@@ -96,14 +103,14 @@ export default function UserMenu() {
                   </Link>
                   <Link
                     href="/admin/groups"
-                    className="block pl-8 pr-4 py-2 text-gray-800 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
+                    className="block py-2 pr-4 pl-8 text-gray-800 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
                     onClick={closeDropdown}
                   >
                     Groups
                   </Link>
                   <Link
                     href="/admin/users"
-                    className="block pl-8 pr-4 py-2 text-gray-800 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
+                    className="block py-2 pr-4 pl-8 text-gray-800 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
                     onClick={closeDropdown}
                   >
                     Users
@@ -113,10 +120,10 @@ export default function UserMenu() {
               <hr className="my-2 border-gray-200 dark:border-gray-700" />
               <button
                 onClick={() => {
-                  signOut({ callbackUrl: '/' });
-                  closeDropdown();
+                  signOut({ callbackUrl: '/' })
+                  closeDropdown()
                 }}
-                className="block w-full text-left px-4 py-2 text-gray-800 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
+                className="block w-full px-4 py-2 text-left text-gray-800 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
               >
                 Logout
               </button>
@@ -142,5 +149,5 @@ export default function UserMenu() {
         </div>
       )}
     </div>
-  );
+  )
 }

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,0 +1,10 @@
+'use server'
+
+import { getPublicUrl } from './storage'
+
+export async function getSecureImageUrl(storagePath: string | null | undefined) {
+  if (!storagePath) {
+    return '/images/default-avatar.png'
+  }
+  return getPublicUrl(storagePath)
+}

--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -1,0 +1,31 @@
+import prisma from './prisma';
+
+/**
+ * Checks if a user has the 'admin' role for a specific group.
+ * @param userId The ID of the user.
+ * @param groupId The ID of the group.
+ * @returns A boolean indicating whether the user is an admin for the group.
+ */
+export async function isAdmin(userId: string, groupId: number): Promise<boolean> {
+  if (!userId || !groupId) {
+    return false;
+  }
+
+  const groupUser = await prisma.groupUser.findUnique({
+    where: {
+      userId_groupId: {
+        userId,
+        groupId,
+      },
+    },
+    include: {
+      role: true, // Include the role information
+    },
+  });
+
+  if (!groupUser || !groupUser.role) {
+    return false;
+  }
+
+  return groupUser.role.code === 'admin';
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,25 +1,38 @@
-'use server';
+'use server'
 
-import { S3Client, PutObjectCommand, DeleteObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
-import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import path from 'path';
-import { writeFile, unlink, mkdir } from 'fs/promises';
-import sharp from 'sharp';
-import { env } from 'process';
+import {
+  S3Client,
+  PutObjectCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+} from '@aws-sdk/client-s3'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+import path from 'path'
+import { writeFile, unlink, mkdir } from 'fs/promises'
+import sharp from 'sharp'
+import { env } from 'process'
 
-const STORAGE_PROVIDER = process.env.NEXT_PUBLIC_STORAGE_PROVIDER || 'local';
-const BUCKET_NAME = env.DO_SPACES_BUCKET || '';
+const STORAGE_PROVIDER = process.env.NEXT_PUBLIC_STORAGE_PROVIDER || 'local'
+const BUCKET_NAME = env.DO_SPACES_BUCKET || ''
 
-const ALLOWED_FORMATS = ['image/jpeg', 'image/png', 'image/webp'];
-const MAX_WIDTH_HEIGHT = 1920; 
+const ALLOWED_FORMATS = ['image/jpeg', 'image/png', 'image/webp', 'image/gif']
+const MAX_WIDTH_HEIGHT = 3840
 
-let s3Client: S3Client | null = null;
+let s3Client: S3Client | null = null
 
-// Note: these env vars are configured in DigitalOcean. Locally, we just save 
+// Note: these env vars are configured in DigitalOcean. Locally, we just save
 // files to the public/uploads directory.
 if (STORAGE_PROVIDER === 'do_spaces') {
-  if (!env.DO_SPACES_KEY || !env.DO_SPACES_SECRET || !env.DO_SPACES_ENDPOINT || !env.DO_SPACES_REGION || !BUCKET_NAME) {
-    throw new Error('DigitalOcean Spaces environment variables are not fully configured.');
+  if (
+    !env.DO_SPACES_KEY ||
+    !env.DO_SPACES_SECRET ||
+    !env.DO_SPACES_ENDPOINT ||
+    !env.DO_SPACES_REGION ||
+    !BUCKET_NAME
+  ) {
+    throw new Error(
+      'DigitalOcean Spaces environment variables are not fully configured.',
+    )
   }
   s3Client = new S3Client({
     region: env.DO_SPACES_REGION,
@@ -29,102 +42,114 @@ if (STORAGE_PROVIDER === 'do_spaces') {
       accessKeyId: env.DO_SPACES_KEY,
       secretAccessKey: env.DO_SPACES_SECRET,
     },
-  });
+  })
 }
 
 async function validateAndResizeImage(file: File): Promise<Buffer> {
   if (!file || file.size === 0) {
-    throw new Error('No file provided.');
+    throw new Error('No file provided.')
   }
 
   if (!ALLOWED_FORMATS.includes(file.type)) {
-    throw new Error('Invalid file format. Only JPG, PNG, and WebP are allowed.');
+    throw new Error('Invalid file format. Only JPG, PNG, WebP, and GIF are allowed.')
   }
 
-  const bytes = await file.arrayBuffer();
-  const buffer = Buffer.from(bytes);
+  const bytes = await file.arrayBuffer()
+  const buffer = Buffer.from(bytes)
 
-  return sharp(buffer).rotate().resize({ width: MAX_WIDTH_HEIGHT, height: MAX_WIDTH_HEIGHT }).toBuffer();
+  return sharp(buffer)
+    .rotate()
+    .resize({ width: MAX_WIDTH_HEIGHT, height: MAX_WIDTH_HEIGHT, fit: 'inside', withoutEnlargement: true })
+    .toBuffer()
 }
 
-export async function uploadFile(file: File, prefix: string, entityId: string | number): Promise<string> {
-  const resizedBuffer = await validateAndResizeImage(file);
-  const extension = file.type.split('/')[1];
-  const filename = `${entityId}.${Date.now()}.${extension}`;
-  const key = `${prefix}/${filename}`;
+export async function uploadFile(
+  file: File,
+  prefix: string,
+  entityId: string | number,
+): Promise<string> {
+  const processedBuffer = await validateAndResizeImage(file)
+  const extension = file.type.split('/')[1]
+  const filename = `${entityId}.${Date.now()}.${extension}`
+  const key = `${prefix}/${filename}`
 
   if (STORAGE_PROVIDER === 'do_spaces' && s3Client) {
     const command = new PutObjectCommand({
       Bucket: BUCKET_NAME,
       Key: key,
-      Body: resizedBuffer,
+      Body: processedBuffer,
       ACL: 'private',
       ContentType: file.type,
-    });
-    await s3Client.send(command);
-    return key;
+    })
+    await s3Client.send(command)
+    return key
   } else {
-    const uploadsDir = path.join(process.cwd(), 'public/uploads', prefix);
-    const filepath = path.join(uploadsDir, filename);
-    await mkdir(uploadsDir, { recursive: true });
-    await writeFile(filepath, resizedBuffer);
+    const uploadsDir = path.join(process.cwd(), 'public/uploads', prefix)
+    const filepath = path.join(uploadsDir, filename)
+    await mkdir(uploadsDir, { recursive: true })
+    await writeFile(filepath, processedBuffer)
     // Return a path relative to the `public`// For local storage, ensure the path is a valid root-relative URL
-    return `uploads/${key}`;
+    return `uploads/${key}`
   }
 }
 
-export async function getPublicUrl(storagePath: string | null | undefined): Promise<string> {
+export async function getPublicUrl(
+  storagePath: string | null | undefined,
+): Promise<string> {
   // 1. Handle the case where there is no image path.
   if (!storagePath) {
-    return '/images/default-avatar.png';
+    return '/images/default-avatar.png'
   }
 
   // 2. Handle full external URLs.
   if (storagePath.startsWith('http')) {
-    return storagePath;
+    return storagePath
   }
 
   // 3. Handle legacy local paths (stored in the public/uploads directory).
   // These paths are stored as 'uploads/...' and need a leading slash.
   if (storagePath.startsWith('uploads/')) {
-    return `/${storagePath}`;
+    return `/${storagePath}`
   }
 
   // 4. Handle already-proxied DigitalOcean Spaces paths.
   if (storagePath.startsWith('/api/images')) {
-    return storagePath;
+    return storagePath
   }
 
   // 5. Handle new DigitalOcean Spaces paths by routing them through our secure proxy.
   // These paths are stored as 'user-photos/...' and need to be prefixed.
   if (STORAGE_PROVIDER === 'do_spaces') {
-    return `/api/images?key=${storagePath}`;
+    return `/api/images?key=${storagePath}`
   }
 
   // 5. Fallback for any other path, ensuring it's a valid root-relative URL.
-  return `/${storagePath.replace(/^\/+/,'')}`;
+  return `/${storagePath.replace(/^\/+/, '')}`
 }
 
 export async function deleteFile(storagePath: string): Promise<void> {
-  if (!storagePath) return;
+  if (!storagePath) return
 
   if (STORAGE_PROVIDER === 'do_spaces' && s3Client) {
-    const command = new DeleteObjectCommand({ Bucket: BUCKET_NAME, Key: storagePath });
+    const command = new DeleteObjectCommand({
+      Bucket: BUCKET_NAME,
+      Key: storagePath,
+    })
     try {
-      await s3Client.send(command);
+      await s3Client.send(command)
     } catch (error) {
-      console.error(`Failed to delete S3 object: ${storagePath}`, error);
+      console.error(`Failed to delete S3 object: ${storagePath}`, error)
     }
   } else {
     try {
       // storagePath is relative to `public`, so we join it directly
-      const filepath = path.join(process.cwd(), 'public', storagePath);
-      await unlink(filepath);
+      const filepath = path.join(process.cwd(), 'public', storagePath)
+      await unlink(filepath)
     } catch (e: unknown) {
-      const error = e as { code?: string };
+      const error = e as { code?: string }
       // It's okay if the file doesn't exist
       if (error.code !== 'ENOENT') {
-        console.error(`Failed to delete local file: ${storagePath}`, error);
+        console.error(`Failed to delete local file: ${storagePath}`, error)
       }
     }
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,6 +43,7 @@ export type MemberWithUser = GroupUser & {
 };
 
 export type GroupData = Group & {
+  logoUrl?: string;
   groupType: GroupType;
   isSuperAdmin: boolean;
   sunDeckMembers: MemberWithUser[];
@@ -57,6 +58,7 @@ export type FullRelationship = UserUser & {
 };
 
 export type FamilyGroupData = Group & {
+  logoUrl?: string;
   groupType: GroupType;
   isSuperAdmin: boolean;
   members: MemberWithUser[];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,7 +43,7 @@ export type MemberWithUser = GroupUser & {
 };
 
 export type GroupData = Group & {
-  logoUrl?: string;
+  logo?: string;
   groupType: GroupType;
   isSuperAdmin: boolean;
   sunDeckMembers: MemberWithUser[];
@@ -58,7 +58,7 @@ export type FullRelationship = UserUser & {
 };
 
 export type FamilyGroupData = Group & {
-  logoUrl?: string;
+  logo?: string;
   groupType: GroupType;
   isSuperAdmin: boolean;
   members: MemberWithUser[];


### PR DESCRIPTION
Allow a group admin to manage the group and users. 

* 8/8/25 - Initial pages at /slug/admin with tabs for Group and Members. Show admin icon for group admins to do their thing. 
* 8/9 - Refined group admin for group data, show group logo and other info in header and modal, various style tweaks. 

This is already big so I'm gonna merge and deploy and continue group user admin in another PR. 