### PR TITLE
Fix prisma client bug

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,26 +1,30 @@
-import { PrismaClient } from '@/generated/prisma';
+import { PrismaClient } from '@/generated/prisma'
 
 declare global {
   // allow global `var` declarations
   // eslint-disable-next-line no-var
-  var prisma: PrismaClient | undefined;
+  var prisma: PrismaClient | undefined
 }
 
-let prisma: PrismaClient;
+let prisma: PrismaClient
 
 if (process.env.NODE_ENV === 'production') {
-  prisma = new PrismaClient();
-} else {
+  // In production, use a global variable to preserve the client across module reloads.
   if (!global.prisma) {
-    global.prisma = new PrismaClient();
+    global.prisma = new PrismaClient()
   }
-  prisma = global.prisma;
+  prisma = global.prisma
+} else {
+  // In development, use a global variable to prevent creating multiple instances
+  // during hot-reloading.
+  if (!global.prisma) {
+    global.prisma = new PrismaClient()
+  }
+  prisma = global.prisma
 }
 
 // Standard client for general use and for the Auth.js adapter
-export default prisma;
+export default prisma
 
 // Extended client for Next.js data caching features.
-export const prismaWithCaching = prisma.$extends({});
-
-
+export const prismaWithCaching = prisma.$extends({})


### PR DESCRIPTION
In prod, we weren't using one prisma client, but recreating new ones causing us to run out of connections. This fix resolves the immediate issue, but it may appear again if there are hundreds of concurrent users. Getting this deployed for now. 

[namegame] [2025-08-10 15:01:57] Too many database connections opened: FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute
[namegame] [2025-08-10 15:01:57] Prisma Accelerate has built-in connection pooling to prevent such errors: https://pris.ly/client/error-accelerate
[namegame] [2025-08-10 15:01:57]     at hI.handleRequestError (.next/server/chunks/9914.js:114:8027)
[namegame] [2025-08-10 15:01:57]     at hI.handleAndLogRequestError (.next/server/chunks/9914.js:114:7087)
[namegame] [2025-08-10 15:01:57]     at hI.request (.next/server/chunks/9914.js:114:6794)
[namegame] [2025-08-10 15:01:57]     at async f (.next/server/chunks/9914.js:126:7668)
[namegame] [2025-08-10 15:01:57]     at async g (.next/server/chunks/2499.js:1:4991)
[namegame] [2025-08-10 15:01:57]     at async p (.next/server/chunks/2499.js:1:3806) {
[namegame] [2025-08-10 15:01:57]   code: 'P2037',
[namegame] [2025-08-10 15:01:57]   clientVersion: '6.12.0',
[namegame] [2025-08-10 15:01:57]   meta: [Object],
[namegame] [2025-08-10 15:01:57]   digest: '2600946535'
[namegame] [2025-08-10 15:01:57] }
