### PR TITLE
Revert prisma accelerator but keep updated build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   },
   "scripts": {
     "dev": "next dev --turbopack",
-    "build-local": "prisma generate && next build",
-    "build": "prisma generate --no-engine && next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
@@ -27,7 +26,6 @@
     "@headlessui/react": "^2.2.4",
     "@paralleldrive/cuid2": "^2.2.2",
     "@prisma/client": "^6.11.1",
-    "@prisma/extension-accelerate": "^2.0.2",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@react-email/components": "^0.3.2",
     "@types/bcrypt": "^6.0.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,7 +1,7 @@
 generator client {
   provider        = "prisma-client-js"
   output          = "../src/generated/prisma"
-  previewFeatures = ["driverAdapters"]
+
 }
 
 datasource db {

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,5 +1,4 @@
 import { PrismaClient } from '@/generated/prisma'
-import { withAccelerate } from '@prisma/extension-accelerate'
 
 declare global {
   // allow global `var` declarations
@@ -10,6 +9,6 @@ declare global {
 const client = global.prisma || new PrismaClient()
 if (process.env.NODE_ENV !== 'production') global.prisma = client
 
-export default client.$extends(withAccelerate()) as unknown as PrismaClient
+export default client
 
 


### PR DESCRIPTION
Prisma accelerator turned out to be a sneaky path to forcing a $50/month fee since it required prisma's static IP feature only available in the "higher" paid tiers (higher for a hobby project, that is). We may come back to it if it makes financial sense, to switch to the open source postgres PgBouncer. It has equivalent functionality but requires a separate DigitalOcean droplet and more effort to configure/manage... but may work the same for $5-10/month, which is the priority right now. 