### PR TITLE
Easier relate access

### DIFF
--- a/src/app/g/[slug]/family/FamilyGroupClient.tsx
+++ b/src/app/g/[slug]/family/FamilyGroupClient.tsx
@@ -345,6 +345,7 @@ export function FamilyGroupClient({
         groupSlug={groupSlug}
         initialRelations={memberRelations}
         onRelationshipAdded={handleRelationshipChange}
+        isReadOnly={!isGroupAdmin && selectedMember?.userId !== currentUserMember?.userId}
       />
     </>
   )

--- a/src/app/g/[slug]/family/FamilyGroupClient.tsx
+++ b/src/app/g/[slug]/family/FamilyGroupClient.tsx
@@ -140,9 +140,11 @@ export function FamilyGroupClient({
       )
       if (result) {
         newMap.set(alter.userId, {
-          label: result.relationship || '',
+          label: result.relationship || 'Relative',
           steps: result.steps,
         })
+      } else {
+        newMap.set(alter.userId, { label: 'Relative', steps: Infinity })
       }
     }
     return newMap
@@ -181,11 +183,16 @@ export function FamilyGroupClient({
   const filteredAndSortedMembers = useMemo(() => {
     let filtered = members
     if (settings.searchQuery) {
-      filtered = members.filter((member) =>
-        `${member.user.firstName} ${member.user.lastName}`
-          .toLowerCase()
-          .includes(settings.searchQuery.toLowerCase()),
-      )
+      filtered = members.filter((member) => {
+        const relationship = relationshipMap.get(member.userId)?.label || ''
+        const name = `${member.user.firstName} ${member.user.lastName}`
+        const searchTerm = settings.searchQuery.toLowerCase()
+
+        return (
+          name.toLowerCase().includes(searchTerm) ||
+          relationship.toLowerCase().includes(searchTerm)
+        )
+      })
     }
 
     if (settings.sortConfig.key === 'closest') {

--- a/src/components/FamilyMemberCard.tsx
+++ b/src/components/FamilyMemberCard.tsx
@@ -65,9 +65,12 @@ export default function FamilyMemberCard({
             {member.user.name}
           </p>
           {relationship && (
-            <p className="text-xs text-blue-500 dark:text-blue-400">
+            <button
+              onClick={() => onRelate && onRelate(member)}
+              className="text-left text-xs text-blue-500 hover:underline focus:outline-none dark:text-blue-400"
+            >
               {relationship}
-            </p>
+            </button>
           )}
         </div>
         <div className={isListView ? 'relative' : 'absolute right-0 top-0'}>
@@ -75,17 +78,9 @@ export default function FamilyMemberCard({
             trigger={<MoreVertical size={16} />}
             triggerClassName="rounded-full p-1 hover:bg-gray-200 dark:hover:bg-gray-700"
           >
-            {isGroupAdmin || member.userId === currentUserId ? (
-              <DropdownItem onClick={() => onRelate && onRelate(member)}>
-                Relate
-              </DropdownItem>
-            ) : (
-              <DropdownItem disabled>
-                <span className="w-full px-2 py-2 text-left text-sm text-gray-500">
-                  Cool options coming!
-                </span>
-              </DropdownItem>
-            )}
+            <DropdownItem onClick={() => onRelate && onRelate(member)}>
+              Relate
+            </DropdownItem>
           </Dropdown>
         </div>
       </div>

--- a/src/components/RelateModal.tsx
+++ b/src/components/RelateModal.tsx
@@ -23,6 +23,7 @@ interface RelateModalProps {
   groupSlug: string
   initialRelations: RelationWithUser[]
   onRelationshipAdded: () => void
+  isReadOnly?: boolean
 }
 
 export default function RelateModal({
@@ -33,6 +34,7 @@ export default function RelateModal({
   groupSlug,
   initialRelations,
   onRelationshipAdded,
+  isReadOnly = false,
 }: RelateModalProps) {
   const [isPending, startTransition] = useTransition()
   const [isDeleting, startDeletingTransition] = useTransition()
@@ -128,8 +130,9 @@ export default function RelateModal({
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={`${member.user.name}`}>
       <div className="mt-4">
-        <form
-          ref={formRef}
+        {!isReadOnly && (
+          <form
+            ref={formRef}
           action={handleSubmit}
           className="rounded-md border border-gray-200 p-4 dark:border-gray-700"
         >
@@ -230,6 +233,7 @@ export default function RelateModal({
             </button>
           </div>
         </form>
+        )}
 
         <div className="mt-6">
           <h4 className="font-medium text-gray-800 dark:text-gray-200">
@@ -250,9 +254,10 @@ export default function RelateModal({
                       ({getRelationLabel(r)})
                     </span>
                   </div>
-                  <button
-                    type="button"
-                    onClick={() => setRelationToDelete(r)}
+                  {!isReadOnly && (
+                    <button
+                      type="button"
+                      onClick={() => setRelationToDelete(r)}
                     className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-500"
                     aria-label={`Delete relationship with ${r.relatedUser.firstName} ${r.relatedUser.lastName}`}
                   >
@@ -271,6 +276,7 @@ export default function RelateModal({
                       />
                     </svg>
                   </button>
+                  )}
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
* Relationships labels now open RelateModal
* Fixed bug so that everyone in a family group has a relationship label... falls back to "Relative" if no other relationship can be calculated. 
* All group members can click to see a person's relationships, but the add/delete options are hidden unless it's their own FamilyMemberCard or they're a group admin. 