### PR TITLE
Email validation and better saving profile

### DIFF
--- a/src/app/(main)/me/_components/user-profile-form.tsx
+++ b/src/app/(main)/me/_components/user-profile-form.tsx
@@ -650,7 +650,7 @@ export default function UserProfileForm({
               onClick={() => setGender(Gender.female)}
               className={`rounded-md px-4 py-2 text-sm font-medium transition-colors ${
                 gender === Gender.female
-                  ? 'bg-pink-600 text-white'
+                  ? 'bg-blue-600 text-white'
                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
               }`}
             >
@@ -661,7 +661,7 @@ export default function UserProfileForm({
               onClick={() => setGender(Gender.non_binary)}
               className={`rounded-md px-4 py-2 text-sm font-medium transition-colors ${
                 gender === Gender.non_binary
-                  ? 'bg-purple-600 text-white'
+                  ? 'bg-blue-600 text-white'
                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
               }`}
             >

--- a/src/app/(main)/me/_components/user-profile-form.tsx
+++ b/src/app/(main)/me/_components/user-profile-form.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useActionState, useEffect, useRef, useState } from 'react'
 import { useFormStatus } from 'react-dom'
 import { toast } from 'sonner'
+import { z } from 'zod'
 import { Badge } from '@/components/ui/badge'
 import Modal from '@/components/ui/modal'
 import { Button } from '@/components/ui/button'
@@ -146,7 +147,8 @@ export default function UserProfileForm({
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [isOptionalOpen, setIsOptionalOpen] = useState(false)
   const [isConfirmModalOpen, setConfirmModalOpen] = useState(false)
-  const [isSubmittingAfterConfirm, setIsSubmittingAfterConfirm] = useState(false)
+  const [isSubmittingAfterConfirm, setIsSubmittingAfterConfirm] =
+    useState(false)
   const [isEmailValid, setIsEmailValid] = useState(
     !user.email || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(user.email),
   )
@@ -652,8 +654,8 @@ export default function UserProfileForm({
                 if (newEmail === '') {
                   setIsEmailValid(true)
                 } else {
-                  const emailRegex = /^[\s\S]*@[\s\S]*\.[\s\S]*$/
-                  setIsEmailValid(emailRegex.test(newEmail))
+                  const result = z.string().email().safeParse(newEmail)
+                  setIsEmailValid(result.success)
                 }
               }}
               className={`block w-full scroll-mt-24 rounded-md border-gray-300 py-2 pr-10 pl-3 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400 ${
@@ -976,7 +978,7 @@ export default function UserProfileForm({
                     onChange={(e) => {
                       setBirthDate(e.target.value)
                     }}
-                    className="block w-full rounded-md border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+                    className="block w-full rounded-md border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none sm:text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
                     placeholder="July 9, 1969, 7/9/69, 1969, etc."
                   />
                 </div>
@@ -996,7 +998,7 @@ export default function UserProfileForm({
                     id="birthPlace"
                     value={birthPlace}
                     onChange={(e) => setBirthPlace(e.target.value)}
-                    className="block w-full rounded-md border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+                    className="block w-full rounded-md border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none sm:text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
                     placeholder="City, State, Country"
                   />
                 </div>

--- a/src/components/GlobalUserForm.tsx
+++ b/src/components/GlobalUserForm.tsx
@@ -20,6 +20,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { Gender } from '@/generated/prisma/client'
+import { z } from 'zod'
 
 export type UserFormData = {
   id?: string
@@ -111,7 +112,7 @@ function SubmitButton({
     <button
       type="submit"
       disabled={pending || disabled}
-      className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50 disabled:bg-indigo-400 dark:focus:ring-offset-gray-800 dark:disabled:bg-indigo-800"
+      className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:outline-none disabled:bg-indigo-400 disabled:opacity-50 dark:focus:ring-offset-gray-800 dark:disabled:bg-indigo-800"
     >
       {pending ? pendingText : text}
     </button>
@@ -214,7 +215,7 @@ export default function GlobalUserForm({
     fileInputRef.current?.click()
   }
 
-  // --- Validation --- 
+  // --- Validation ---
   const validateUsername = (username: string) => {
     if (!username) {
       return 'Username is required.'
@@ -233,8 +234,12 @@ export default function GlobalUserForm({
   }
 
   const validateEmail = (email: string) => {
-    if (email && !/^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/.test(email)) {
-      return 'Invalid email address.'
+    if (!email) {
+      return null
+    }
+    const result = z.string().email('Invalid email address.').safeParse(email)
+    if (!result.success) {
+      return result.error.issues[0].message
     }
     return null
   }
@@ -409,7 +414,9 @@ export default function GlobalUserForm({
     const isFirstNameValid = !validateFirstName(formState.firstName)
     const isEmailValid = !validateEmail(formState.email)
 
-    return isUsernameValid && isFirstNameValid && isPasswordValid && isEmailValid
+    return (
+      isUsernameValid && isFirstNameValid && isPasswordValid && isEmailValid
+    )
   }, [
     formState.username,
     formState.firstName,

--- a/src/components/ui/StickySaveBar.tsx
+++ b/src/components/ui/StickySaveBar.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { Button } from './button'
+
+interface StickySaveBarProps {
+  isDirty: boolean
+  isFormValid: boolean
+  onSave: () => void
+  onDiscard: () => void
+}
+
+export default function StickySaveBar({
+  isDirty,
+  isFormValid,
+  onSave,
+  onDiscard,
+}: StickySaveBarProps) {
+  if (!isDirty) {
+    return null
+  }
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-50 border-t border-gray-200 bg-white/80 p-4 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-900/80">
+      <div className="container mx-auto flex items-center justify-between">
+        <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          You have unsaved changes.
+        </p>
+        <div className="flex items-center space-x-4">
+          <Button variant="ghost" onClick={onDiscard}>
+            Discard
+          </Button>
+          <Button onClick={onSave} disabled={!isFormValid}>
+            Save Changes
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
* Consistently use the zod email validator and remove differing custom regexes. Support + in email for valid tags (e.g. wendy+namegame@gmail.com, etc.)
* Add a sticky save bar to always see the Save/Discard buttons in the user profile form when form is dirty so user doesn't forget to click save (when they had to scroll down to do it. 
* Make gender buttons same color. Gemini had made them blue, pink, purple without asking me. 