### PR TITLE
Health check css

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,27 +1,27 @@
-name: Playwright Tests
+# name: Playwright Tests
 # on:
 #   push:
 #     branches: [ main, master ]
 #   pull_request:
 #     branches: [ main, master ]
-jobs:
-  test:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-      - name: Install dependencies
-        run: npm ci
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
-      - name: Run Playwright tests
-        run: npx playwright test
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
+# jobs:
+#   test:
+#     timeout-minutes: 60
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#       - uses: actions/setup-node@v4
+#         with:
+#           node-version: lts/*
+#       - name: Install dependencies
+#         run: npm ci
+#       - name: Install Playwright Browsers
+#         run: npx playwright install --with-deps
+#       - name: Run Playwright tests
+#         run: npx playwright test
+#       - uses: actions/upload-artifact@v4
+#         if: ${{ !cancelled() }}
+#         with:
+#           name: playwright-report
+#           path: playwright-report/
+#           retention-days: 30

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server'
+
+// This route is used by the hosting provider (DigitalOcean) to check if the
+// application is healthy and ready to receive traffic. It helps ensure zero-downtime
+// deployments by verifying that the app can fully render a page, including its
+// static assets like CSS.
+
+export async function GET(request: Request) {
+  const host = request.headers.get('host')
+  if (!host) {
+    return NextResponse.json(
+      { status: 'error', message: 'Host header is missing' },
+      { status: 400 },
+    )
+  }
+
+  // Use http for internal health checks, even if the public site is https
+  const protocol = host.startsWith('localhost') ? 'http' : 'https'
+  const baseUrl = `${protocol}://${host}`
+
+  try {
+    // 1. Fetch the homepage to ensure the Next.js server is responding.
+    const homepageRes = await fetch(baseUrl, {
+      signal: AbortSignal.timeout(5000), // 5-second timeout
+    })
+
+    if (!homepageRes.ok) {
+      throw new Error(
+        `Homepage fetch failed with status: ${homepageRes.status}`,
+      )
+    }
+
+    // 2. Parse the HTML to find stylesheet links.
+    const html = await homepageRes.text()
+    const stylesheetLinks = html.match(
+      /<link[^>]+rel="stylesheet"[^>]+href="([^"\s]+)"/g,
+    )
+
+    if (!stylesheetLinks || stylesheetLinks.length === 0) {
+      throw new Error('No stylesheets found in the homepage HTML.')
+    }
+
+    // 3. Check that each critical stylesheet is available.
+    const assetChecks = stylesheetLinks.map((link) => {
+      const hrefMatch = link.match(/href="([^"\s]+)"/)
+      if (!hrefMatch || !hrefMatch[1]) {
+        throw new Error('Found a stylesheet link with no href.')
+      }
+      const assetUrl = new URL(hrefMatch[1], baseUrl).toString()
+      return fetch(assetUrl, { signal: AbortSignal.timeout(5000) }).then(
+        (res) => {
+          if (!res.ok) {
+            throw new Error(
+              `Failed to fetch asset ${assetUrl}: status ${res.status}`,
+            )
+          }
+          return res.ok
+        },
+      )
+    })
+
+    await Promise.all(assetChecks)
+
+    // If all checks pass, the application is healthy.
+    return NextResponse.json({ status: 'ok' })
+  } catch (error) {
+    console.error('Health check failed:', error)
+    // If any error occurs, the app is not ready for traffic.
+    return NextResponse.json(
+      { status: 'error', message: (error as Error).message },
+      { status: 503 }, // 503 Service Unavailable
+    )
+  }
+}


### PR DESCRIPTION
Digital ocean deploys had a short window between when new code was deployed on the node server, but static stuff (css, built js) wasn't yet available on the CDN, causing production pages to load with no styling and look broken. 

This adds a health check that confirms it's getting css (from cdn) before it starts serving the newly deployed changes. Between the new /api/health route and this app config in d.o.
<img width="711" height="361" alt="image" src="https://github.com/user-attachments/assets/0d3679aa-d9dd-415f-aeae-f9f8460070ea" />

Deploying this first so the endpoint is available, then I'll save the setting so it does the check. 