### PR TITLE
Dummy change to trigger new deploy

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server'
 
 // This route is used by the hosting provider (DigitalOcean) to check if the
-// application is healthy and ready to receive traffic. It helps ensure zero-downtime
-// deployments by verifying that the app can fully render a page, including its
-// static assets like CSS.
+// application is healthy and ready to receive traffic. It helps ensure
+// zero-downtime deployments by verifying that the app can fully render a page,
+// including its static assets like CSS.
 
 export async function GET(request: Request) {
   const host = request.headers.get('host')


### PR DESCRIPTION
Last deploy was cancelled because I saved an app config change to use the new /api/health endpoint, thinking it was do that deploy with the latest from main in github, but it didn't. And D.O. doesn't have a simple way to re-deploy from github, hence this whitespace change to trigger it. 