### PR TITLE
Fix timezone

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,7 +2,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 import { DatePrecision } from '@/generated/prisma/client'
 import { isValid, parse } from 'date-fns'
-import { format, toZonedTime } from 'date-fns-tz'
+import { format, fromZonedTime } from 'date-fns-tz'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -59,33 +59,26 @@ export function parseDateAndDeterminePrecision(
     const parsedDate = parse(normalizedDateString, fmt, new Date())
 
     if (isValid(parsedDate)) {
-      // When a date string without timezone info is parsed, it's treated as local time on the server.
-      // To get the correct UTC time that represents the start of the day in the user's timezone,
-      // we use toZonedTime to convert the parsed (local) date to the correct UTC equivalent.
-      const zonedDate = toZonedTime(parsedDate, timeZone)
+      // When a date string without a timezone is parsed, date-fns creates a Date object
+      // assuming the server's local timezone (e.g., UTC). This causes an off-by-one error.
+      // To fix this, we use `fromZonedTime` to correctly interpret the parsed date
+      // as a local time in the user's timezone and get the UTC equivalent.
 
       // Post-process two-digit years to ensure correct century.
-      if (fmt.includes('yy')) {
-        const year = zonedDate.getFullYear()
+      if (fmt.includes('yy') && !fmt.includes('yyyy')) {
+        const year = parsedDate.getFullYear()
         const currentYear = new Date().getFullYear()
-
-        // If date-fns parses a 2-digit year as a year between 0 and 99, it's ambiguous.
-        if (year >= 0 && year < 100) {
-          const correctedDate = new Date(zonedDate.getTime())
-          correctedDate.setFullYear(year + 1900)
-          return { date: correctedDate, precision }
-        }
-
-        // If date-fns parses a 'yy' value, it may choose the closest year in the future.
-        // For example, in 2024, '74' becomes 2074. We correct this to 1974.
-        if (year > currentYear + 30) {
-          const correctedDate = new Date(zonedDate.getTime())
-          correctedDate.setFullYear(year - 100)
-          return { date: correctedDate, precision }
+        // If date-fns parses '74' as 2074, correct it to the 20th century.
+        if (year > currentYear) {
+          parsedDate.setFullYear(year - 100)
         }
       }
 
-      return { date: zonedDate, precision }
+      // Treat the parsed date as wall-clock time in the user's timezone
+      // and get the corresponding UTC time for storage.
+      const utcDate = fromZonedTime(parsedDate, timeZone)
+
+      return { date: utcDate, precision }
     }
   }
 


### PR DESCRIPTION
Now we should correctly save and display dates (at least birthDate):

* Detect user's timezone from device locale
  * e.g. Mountain Time
* Convert date/time from local to UTC
  * e.g. 7/9/74 -> 1974-07-08 6:00:00 PM (UTC-6)
* Save to the database as UTC (1974-07-08 6:00:00 PM)
* When queried, load it back to local timezone: 1974-07-09 12:00:00 AM

Same if time is included in the birthDate.

  * e.g. 7/9/74 9:00 AM -> 1974-07-09 3:00:00 AM (UTC-6)
  * Displays as 1974-07-09 9:00:00 AM in Mountain Time