### PR TITLE
Fix monorepo build: add package build scripts and declaration files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev:worker": "pnpm --filter worker dev",
     "dev:chat": "pnpm --filter chat dev",
     "build": "pnpm --filter web build",
-    "build:all": "pnpm -r build",
+    "build:all": "pnpm --filter \"./packages/*\" build && pnpm --filter \"./apps/*\" build",
     "start": "pm2 start ecosystem.config.js",
     "start:web": "pnpm --filter web start",
     "stop": "pm2 stop ecosystem.config.js",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -2,9 +2,10 @@
   "name": "@namegame/db",
   "version": "0.0.0",
   "private": true,
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
+    "build": "tsc",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
@@ -16,6 +17,7 @@
   },
   "devDependencies": {
     "prisma": "^6.11.1",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.0"
   }
 }

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,18 +1,20 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "commonjs",
-    "lib": ["ES2020"],
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "node",
     "outDir": "./dist",
-    "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "moduleResolution": "node",
+    "isolatedModules": true,
+    "noEmit": false,
     "declaration": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "prisma/migrations"]
 }

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -2,9 +2,16 @@
   "name": "@namegame/queue",
   "version": "0.0.0",
   "private": true,
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc"
+  },
   "dependencies": {
     "graphile-worker": "^0.16.6"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "@types/node": "^20.0.0"
   }
 }

--- a/packages/queue/src/index.ts
+++ b/packages/queue/src/index.ts
@@ -5,7 +5,7 @@
  * different implementations (Postgres via Graphile Worker, Redis via BullMQ, etc.)
  */
 
-export * from './types';
-export { GraphileWorkerQueue } from './graphile-worker';
+export * from './types.js';
+export { GraphileWorkerQueue } from './graphile-worker.js';
 
 // Future: export { BullMQQueue } from './bullmq';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,12 +312,22 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.18.8)(typescript@5.9.2)
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.2
 
   packages/queue:
     dependencies:
       graphile-worker:
         specifier: ^0.16.6
         version: 0.16.6(typescript@5.9.2)
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.18
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.2
 
 packages:
 


### PR DESCRIPTION
- Add build scripts to packages/db and packages/queue
- Add TypeScript configs with declaration generation
- Fix import extensions in queue package
- Update build:all to build packages before apps
- Resolves TypeScript module resolution errors in production