### PR TITLE
Add downloaded appspecs with job config in namegame.yaml (local only,…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ node_modules/
 
 # PM2 logs
 logs/
+
+# DigitalOcean app specs (contain secrets)
+.do/

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -54,11 +54,13 @@ async function main() {
       connectionString: queueConnectionString,
       concurrency: 5, // Process up to 5 jobs concurrently
       pollInterval: 1000, // Check for new jobs every second
-      crontab: `
-        # Daily chat notifications at 12:30 PM Mountain Time (18:30 UTC in winter, 19:30 UTC in summer)
-        # Using 19:30 UTC as a compromise (12:30 PM MDT)
-        30 19 * * * send-daily-chat-notifications
-      `,
+      // NOTE: Crontab disabled due to RLS permissions on DigitalOcean managed DB
+      // Use manual trigger or external cron instead: apps/worker/scripts/trigger-daily-notifications.ts
+      // crontab: `
+      //   # Daily chat notifications at 12:30 PM Mountain Time (18:30 UTC in winter, 19:30 UTC in summer)
+      //   # Using 19:30 UTC as a compromise (12:30 PM MDT)
+      //   30 19 * * * send-daily-chat-notifications
+      // `,
     },
     jobs
   );


### PR DESCRIPTION
… not tracked)

We don't want the app config files from digitalocean tracked here because they have secrets. Will manage those locally. 

This mainly removes the old cron that didn't work with d.o. We modified the namegame app config yaml file and re-uploaded it to do it their way... each day at 12:30 mountain time, send push notifications to people have have new unread chat messages. 