### PR TITLE
Add createdAt timestamp to push subscriptions list

### DIFF
--- a/apps/web/src/actions/push.ts
+++ b/apps/web/src/actions/push.ts
@@ -209,7 +209,7 @@ export async function getSubscription(
 }
 
 export async function getSubscriptions(): Promise<
-  { endpoint: string; userName: string | null; userId: string }[]
+  { endpoint: string; userName: string | null; userId: string; createdAt: Date }[]
 > {
   const subscriptions = await db.pushSubscription.findMany({
     include: {
@@ -219,12 +219,16 @@ export async function getSubscriptions(): Promise<
         },
       },
     },
+    orderBy: {
+      createdAt: 'desc', // Most recent first
+    },
   })
 
   return subscriptions.map((sub) => ({
     endpoint: sub.endpoint,
     userName: sub.user.firstName,
     userId: sub.userId,
+    createdAt: sub.createdAt,
   }))
 }
 

--- a/apps/web/src/app/(main)/me/push-test/push-test-client.tsx
+++ b/apps/web/src/app/(main)/me/push-test/push-test-client.tsx
@@ -10,6 +10,7 @@ type Subscription = {
   endpoint: string
   userName: string | null
   userId: string
+  createdAt: Date
 }
 
 function getBrowserInfo(endpoint: string): string {
@@ -144,7 +145,7 @@ export function PushTestClientPage() {
                 htmlFor={sub.endpoint}
                 className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
               >
-                {sub.userName} - {getBrowserInfo(sub.endpoint)}
+                {sub.userName} - {getBrowserInfo(sub.endpoint)} - {new Date(sub.createdAt).toLocaleString()}
               </label>
             </div>
           ))}


### PR DESCRIPTION
- Show subscription creation time in push test page
- Sort subscriptions by most recent first
- Helps identify which device was just subscribed