### PR TITLE
Cosmic insights page

### DIFF
--- a/apps/web/src/app/(main)/cosmic-insights/[id]/page.tsx
+++ b/apps/web/src/app/(main)/cosmic-insights/[id]/page.tsx
@@ -1,0 +1,341 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { useSession } from 'next-auth/react'
+
+interface CosmicInsightsData {
+  id: string
+  userId: string
+  userName: string
+  memberFirstName?: string
+  scores: {
+    proximity: number
+    interest: number
+    personalTime: number
+    commonGround: number
+    familiarity: number
+  }
+  starScore: number
+  relationshipLabel: string
+  relationshipGoals?: string
+  response: string
+  createdAt: string
+}
+
+export default function CosmicInsightsPage() {
+  const params = useParams()
+  const router = useRouter()
+  const { status } = useSession()
+  const [data, setData] = useState<CosmicInsightsData | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await fetch(`/api/cosmic-insights/${params.id}`)
+        
+        if (!response.ok) {
+          if (response.status === 403) {
+            // Unauthorized - redirect to home
+            router.push('/')
+            return
+          } else if (response.status === 404) {
+            setError('Assessment not found.')
+          } else {
+            setError('Failed to load assessment.')
+          }
+          return
+        }
+
+        const result = await response.json()
+        setData(result)
+      } catch {
+        setError('An error occurred while loading the assessment.')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    if (status === 'unauthenticated') {
+      router.push(`/auth/signin?callbackUrl=/cosmic-insights/${params.id}`)
+      return
+    }
+
+    if (status === 'authenticated') {
+      fetchData()
+    }
+  }, [status, params.id, router])
+
+  if (isLoading || status === 'loading') {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-center">
+          <div className="mx-auto h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600"></div>
+          <p className="mt-4 text-sm text-gray-600 dark:text-gray-400">
+            Loading Cosmic Insights...
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-screen items-center justify-center p-4">
+        <div className="max-w-md text-center">
+          <h1 className="mb-4 text-2xl font-bold text-gray-900 dark:text-gray-100">
+            Unable to Load Assessment
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400">{error}</p>
+          <button
+            onClick={() => router.push('/')}
+            className="mt-6 rounded-lg bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700"
+          >
+            Go Home
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!data) {
+    return null
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8 pb-24">
+      {/* Header */}
+      <div className="mb-8">
+        <h1 className="mb-2 text-3xl font-bold text-gray-900 dark:text-gray-100">
+          Cosmic Insights
+          {data.memberFirstName && ` with ${data.memberFirstName}`}
+        </h1>
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          Created {new Date(data.createdAt).toLocaleDateString()} at{' '}
+          {new Date(data.createdAt).toLocaleTimeString()} by {data.userName}
+        </p>
+      </div>
+
+      {/* Content Grid */}
+      <div className="grid gap-8 lg:grid-cols-2">
+        {/* Left: Context and Insights */}
+        <div className="space-y-6">
+          {data.relationshipGoals && (
+            <div className="rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+              <h2 className="mb-4 text-xl font-bold">Relationship Context</h2>
+              <div className="text-sm text-gray-700 dark:text-gray-300">
+                {data.relationshipGoals}
+              </div>
+            </div>
+          )}
+
+          <div className="rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+            <h2 className="mb-4 text-xl font-bold">
+              Cosmic Insights from the Stars
+            </h2>
+            <div
+              className="prose prose-sm prose-indigo dark:prose-invert max-w-none text-gray-800 dark:text-gray-200 [&_li]:leading-relaxed [&_ul]:space-y-3 [&>div]:space-y-2 [&>p]:mb-4"
+              dangerouslySetInnerHTML={{ __html: data.response }}
+            />
+          </div>
+        </div>
+
+        {/* Right: Chart and Score */}
+        <div className="space-y-6">
+          {/* Star Chart */}
+          <div className="rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+            <h2 className="mb-4 text-xl font-bold">Star Chart</h2>
+            <div className="relative mx-auto aspect-square w-full">
+              <svg viewBox="-10 -10 340 340" className="h-full w-full">
+                {/* Center point */}
+                <circle cx="160" cy="160" r="3" fill="#4f46e5" />
+
+                {/* Concentric circles */}
+                {[32, 64, 96, 128, 160].map((radius) => (
+                  <circle
+                    key={radius}
+                    cx="160"
+                    cy="160"
+                    r={radius}
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1"
+                    className="stroke-gray-300 dark:stroke-gray-600"
+                  />
+                ))}
+
+                {/* Scale labels */}
+                {[0, 5, 10].map((val) => (
+                  <text
+                    key={val}
+                    x="160"
+                    y={160 - val * 16 - (val === 0 ? 12 : 0) + 5}
+                    textAnchor="middle"
+                    fontSize="14"
+                    fontWeight="500"
+                    fill="currentColor"
+                    className="fill-gray-500 dark:fill-gray-400"
+                  >
+                    {val}
+                  </text>
+                ))}
+
+                {/* Axes */}
+                {Object.keys(data.scores).map((_, idx) => {
+                  const angle = (idx * (360 / 5) - 90 + 30) * (Math.PI / 180)
+                  const x = 160 + 160 * Math.cos(angle)
+                  const y = 160 + 160 * Math.sin(angle)
+                  return (
+                    <line
+                      key={idx}
+                      x1="160"
+                      y1="160"
+                      x2={x}
+                      y2={y}
+                      stroke="currentColor"
+                      strokeWidth="1"
+                      className="stroke-gray-300 dark:stroke-gray-600"
+                    />
+                  )
+                })}
+
+                {/* Filled area */}
+                <path
+                  d={
+                    Object.values(data.scores)
+                      .map((value, idx) => {
+                        const angle =
+                          (idx * (360 / 5) - 90 + 30) * (Math.PI / 180)
+                        const length = value * 16
+                        const x = 160 + length * Math.cos(angle)
+                        const y = 160 + length * Math.sin(angle)
+                        return `${idx === 0 ? 'M' : 'L'} ${x} ${y}`
+                      })
+                      .join(' ') + ' Z'
+                  }
+                  fill="#4f46e5"
+                  fillOpacity="0.15"
+                  stroke="#4f46e5"
+                  strokeWidth="3"
+                  opacity="0.6"
+                />
+
+                {/* Points */}
+                {Object.values(data.scores).map((value, idx) => {
+                  const angle = (idx * (360 / 5) - 90 + 30) * (Math.PI / 180)
+                  const length = value * 16
+                  const x = 160 + length * Math.cos(angle)
+                  const y = 160 + length * Math.sin(angle)
+
+                  return (
+                    <g key={idx}>
+                      <circle
+                        cx={x}
+                        cy={y}
+                        r="6"
+                        fill="#4f46e5"
+                        stroke="white"
+                        strokeWidth="2"
+                      />
+                    </g>
+                  )
+                })}
+
+                {/* Labels */}
+                {[
+                  { key: 'proximity', label: 'Proximity' },
+                  { key: 'interest', label: 'Interest' },
+                  { key: 'personalTime', label: 'Personal\nTime' },
+                  { key: 'commonGround', label: 'Common\nGround' },
+                  { key: 'familiarity', label: 'Familiarity' },
+                ].map((dim, idx) => {
+                  const angle = (idx * (360 / 5) - 90 + 30) * (Math.PI / 180)
+                  const labelDistance = 145
+                  const x = 160 + labelDistance * Math.cos(angle)
+                  const y = 160 + labelDistance * Math.sin(angle)
+
+                  return (
+                    <text
+                      key={dim.key}
+                      x={x}
+                      y={y}
+                      textAnchor="middle"
+                      dominantBaseline="middle"
+                      fontSize="14"
+                      fontWeight="600"
+                      fill="currentColor"
+                      className="fill-gray-700 dark:fill-gray-300"
+                    >
+                      {dim.label.split('\n').map((line, i) => (
+                        <tspan key={i} x={x} dy={i === 0 ? 0 : 16}>
+                          {line}
+                        </tspan>
+                      ))}
+                    </text>
+                  )
+                })}
+              </svg>
+            </div>
+          </div>
+
+          {/* Star Score */}
+          <div className="rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+            <h2 className="mb-4 text-xl font-bold">Star Score</h2>
+            <div className="mb-4 text-center">
+              <div className="font-bold">
+                <span className="text-4xl text-indigo-600 dark:text-indigo-400">
+                  {data.starScore}
+                </span>
+                <span className="text-2xl text-gray-400">/10</span>
+              </div>
+              <div className="mt-2 text-sm font-medium text-gray-600 dark:text-gray-400">
+                {data.relationshipLabel}
+              </div>
+            </div>
+
+            <div className="space-y-2 text-sm">
+              <div className="flex justify-between">
+                <span className="text-gray-600 dark:text-gray-400">
+                  Personal Time (30%)
+                </span>
+                <span className="font-medium">
+                  {data.scores.personalTime}/10
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600 dark:text-gray-400">
+                  Common Ground (25%)
+                </span>
+                <span className="font-medium">
+                  {data.scores.commonGround}/10
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600 dark:text-gray-400">
+                  Familiarity (20%)
+                </span>
+                <span className="font-medium">
+                  {data.scores.familiarity}/10
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600 dark:text-gray-400">
+                  Interest (15%)
+                </span>
+                <span className="font-medium">{data.scores.interest}/10</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600 dark:text-gray-400">
+                  Proximity (10%)
+                </span>
+                <span className="font-medium">{data.scores.proximity}/10</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/api/cosmic-insights/[id]/route.ts
+++ b/apps/web/src/app/api/cosmic-insights/[id]/route.ts
@@ -1,0 +1,102 @@
+// API endpoint to fetch a specific Cosmic Insights assessment
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import prisma from '@/lib/prisma'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    // 1. Check authentication
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      )
+    }
+
+    const { id } = params
+
+    // 2. Fetch the AI request
+    const aiRequest = await prisma.aIRequest.findUnique({
+      where: { id },
+      include: {
+        user: {
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+          },
+        },
+      },
+    })
+
+    if (!aiRequest) {
+      return NextResponse.json(
+        { error: 'Assessment not found' },
+        { status: 404 }
+      )
+    }
+
+    // 3. Verify the current user owns this assessment
+    if (aiRequest.userId !== session.user.id) {
+      return NextResponse.json(
+        { error: 'You do not have permission to view this assessment' },
+        { status: 403 }
+      )
+    }
+
+    // 4. Parse the request input to get the scores and context
+    const requestInput = JSON.parse(aiRequest.requestInput)
+
+    // 5. Extract scores (they're nested in a scores object)
+    const scores = requestInput.scores || {
+      proximity: 0,
+      interest: 0,
+      personalTime: 0,
+      commonGround: 0,
+      familiarity: 0,
+    }
+
+    const starScore =
+      scores.personalTime * 0.3 +
+      scores.commonGround * 0.25 +
+      scores.familiarity * 0.2 +
+      scores.interest * 0.15 +
+      scores.proximity * 0.1
+
+    const relationshipLabel =
+      starScore >= 8
+        ? 'Close Friend'
+        : starScore >= 5
+        ? 'Friend'
+        : starScore >= 3
+        ? 'Acquaintance'
+        : starScore >= 1
+        ? 'Nodding Acquaintance'
+        : 'Stranger'
+
+    // 6. Return the assessment data
+    return NextResponse.json({
+      id: aiRequest.id,
+      userId: aiRequest.userId,
+      userName: `${aiRequest.user.firstName} ${aiRequest.user.lastName || ''}`.trim(),
+      memberFirstName: requestInput.memberFirstName,
+      scores,
+      starScore: parseFloat(starScore.toFixed(1)),
+      relationshipLabel,
+      relationshipGoals: requestInput.relationshipGoals,
+      response: aiRequest.response,
+      createdAt: aiRequest.requestedAt.toISOString(),
+    })
+  } catch (error) {
+    console.error('Error fetching cosmic insights:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch assessment' },
+      { status: 500 }
+    )
+  }
+}

--- a/apps/web/src/app/api/cosmic-insights/[id]/route.ts
+++ b/apps/web/src/app/api/cosmic-insights/[id]/route.ts
@@ -6,7 +6,7 @@ import prisma from '@/lib/prisma'
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     // 1. Check authentication
@@ -18,7 +18,7 @@ export async function GET(
       )
     }
 
-    const { id } = params
+    const { id } = await params
 
     // 2. Fetch the AI request
     const aiRequest = await prisma.aIRequest.findUnique({

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,15 +1,18 @@
 'use client'
 
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import UserMenu from './UserMenu'
 import Image from 'next/image'
 import { GroupData } from '@/types'
-import { Settings } from 'lucide-react'
+import { Settings, ArrowLeft, ArrowRight } from 'lucide-react'
 import GroupInfoModal from './GroupInfoModal'
 import ChatIcon, { ChatIconRef } from './ChatIcon'
 import ChatDeepLink from './ChatDeepLink'
 import RefreshButton from './ui/RefreshButton'
+import { useSession } from 'next-auth/react'
+import { useDeviceInfo } from '@/hooks/useDeviceInfo'
 
 interface HeaderProps {
   group?: GroupData | null
@@ -24,6 +27,27 @@ export default function Header({
 }: HeaderProps) {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const chatIconRef = useRef<ChatIconRef>(null)
+  const router = useRouter()
+  const { data: session } = useSession()
+  const deviceInfo = useDeviceInfo(session)
+  const [canGoBack, setCanGoBack] = useState(false)
+  const [canGoForward, setCanGoForward] = useState(false)
+
+  useEffect(() => {
+    // Check navigation state
+    const updateNavState = () => {
+      setCanGoBack(window.history.length > 1)
+      // Note: There's no reliable way to detect forward history in browsers
+      // We keep it enabled to match browser UI. The router.forward() will simply
+      // do nothing if there's no forward history available.
+      setCanGoForward(true)
+    }
+
+    updateNavState()
+    // Listen for navigation changes
+    window.addEventListener('popstate', updateNavState)
+    return () => window.removeEventListener('popstate', updateNavState)
+  }, [])
 
   const handleOpenChat = () => {
     chatIconRef.current?.openChat()
@@ -34,42 +58,73 @@ export default function Header({
       <ChatDeepLink onOpenChat={handleOpenChat} />
       <header id="page-header" className="bg-background border-border sticky top-0 left-0 z-50 w-full border-b">
         <div className="container mx-auto flex h-full items-center justify-between px-5 py-1">
-          {group ? (
-            <button
-              onClick={() => setIsModalOpen(true)}
-              className="flex items-center gap-2 text-left"
-              data-tour="group-name"
-            >
-              {group.logo && (
+          <div className="flex items-center gap-2">
+            {/* PWA Navigation Controls */}
+            {deviceInfo.isPWA && (
+              <>
+                <button
+                  onClick={() => router.back()}
+                  disabled={!canGoBack}
+                  className="text-gray-600 hover:text-gray-900 disabled:text-gray-400 disabled:cursor-not-allowed dark:text-gray-400 dark:hover:text-gray-100 dark:disabled:text-gray-600"
+                  aria-label="Go back"
+                >
+                  <ArrowLeft size={24} />
+                </button>
+                <button
+                  onClick={() => router.forward()}
+                  disabled={!canGoForward}
+                  className="text-gray-600 hover:text-gray-900 disabled:text-gray-400 disabled:cursor-not-allowed dark:text-gray-400 dark:hover:text-gray-100 dark:disabled:text-gray-600"
+                  aria-label="Go forward"
+                >
+                  <ArrowRight size={24} />
+                </button>
+                <RefreshButton />
+              </>
+            )}
+
+            {/* Logo/Group Name */}
+            {group ? (
+              <button
+                onClick={() => setIsModalOpen(true)}
+                className="flex items-center gap-2 text-left"
+                data-tour="group-name"
+              >
+                {group.logo && (
+                  <Image
+                    src={group.logo}
+                    alt={`${group.name} logo`}
+                    width={32}
+                    height={32}
+                    className="h-10 w-10 object-cover"
+                  />
+                )}
+                {/* Show group name on desktop, hide on mobile if in PWA */}
+                <span className={`block max-w-[200px] truncate text-xl font-bold text-gray-600 dark:text-gray-200 ${
+                  deviceInfo.isPWA && deviceInfo.isMobile ? 'hidden' : 'sm:max-w-none'
+                }`}>
+                  {group.name}
+                </span>
+              </button>
+            ) : (
+              <Link
+                href="/"
+                className="flex items-center gap-1 text-xl font-bold text-gray-600 dark:text-gray-200"
+              >
                 <Image
-                  src={group.logo}
-                  alt={`${group.name} logo`}
+                  src="/images/butterfly.png"
+                  alt="NameGame social butterfly"
                   width={32}
                   height={32}
-                  className="h-10 w-10 object-cover"
+                  className="h-auto md:max-w-[32px]"
                 />
-              )}
-              <span className="block max-w-[200px] truncate text-xl font-bold text-gray-600 sm:max-w-none dark:text-gray-200">
-                {group.name}
-              </span>
-            </button>
-          ) : (
-            <Link
-              href="/"
-              className="flex items-center text-xl font-bold text-gray-600 dark:text-gray-200"
-            >
-              <Image
-                src="/images/butterfly.png"
-                alt="NameGame social butterfly"
-                width={32}
-                height={32}
-                className="mx-auto h-auto md:max-w-[32px]"
-              />
-              NameGame
-            </Link>
-          )}
+                {/* Show NameGame text only on desktop or when not in PWA mobile */}
+                <span className={deviceInfo.isPWA && deviceInfo.isMobile ? 'hidden' : ''}>
+                  NameGame
+                </span>
+              </Link>
+            )}
+          </div>
           <div className="flex items-center gap-4">
-            <RefreshButton />
             {isGroupAdmin && groupSlug && (
               <Link
                 href={`/g/${groupSlug}/admin`}

--- a/apps/web/src/components/RelationStarModal.tsx
+++ b/apps/web/src/components/RelationStarModal.tsx
@@ -54,7 +54,9 @@ export default function RelationStarModal({
 }: RelationStarModalProps) {
   const [isLoadingHistory, setIsLoadingHistory] = useState(false)
   const [snapshots, setSnapshots] = useState<Snapshot[]>([])
-  const [selectedSnapshotId, setSelectedSnapshotId] = useState<string | null>(null)
+  const [selectedSnapshotId, setSelectedSnapshotId] = useState<string | null>(
+    null,
+  )
 
   const router = useRouter()
   const { data: session } = useSession()
@@ -71,7 +73,9 @@ export default function RelationStarModal({
   })
   const [relationshipGoals, setRelationshipGoals] = useState('')
   const [aiInsight, setAiInsight] = useState<string | null>(null)
-  const [currentAssessmentId, setCurrentAssessmentId] = useState<string | null>(null)
+  const [currentAssessmentId, setCurrentAssessmentId] = useState<string | null>(
+    null,
+  )
   const [isLoadingAI, setIsLoadingAI] = useState(false)
   const [isSlidersCollapsed, setIsSlidersCollapsed] = useState(false)
   const [aiError, setAiError] = useState<string | null>(null)
@@ -80,7 +84,9 @@ export default function RelationStarModal({
   const fetchHistory = useCallback(async () => {
     setIsLoadingHistory(true)
     try {
-      const response = await fetch(`/api/relation-star/history?memberId=${memberId}`)
+      const response = await fetch(
+        `/api/relation-star/history?memberId=${memberId}`,
+      )
       const data = await response.json()
 
       if (response.ok && data.assessments) {
@@ -266,14 +272,19 @@ export default function RelationStarModal({
                               </TooltipTrigger>
                               <TooltipContent side="right" className="max-w-xs">
                                 <p className="mb-2">
-                                  Learn how to interpret your star chart and understand the five dimensions of relationships.
+                                  Learn how to interpret your star chart and
+                                  understand the five dimensions of
+                                  relationships.
                                 </p>
                                 <button
                                   onClick={() => {
                                     if (deviceInfo.isPWA) {
                                       router.push('/relation-star-demo')
                                     } else {
-                                      window.open('/relation-star-demo', '_blank')
+                                      window.open(
+                                        '/relation-star-demo',
+                                        '_blank',
+                                      )
                                     }
                                   }}
                                   className="text-white hover:text-gray-200 underline font-semibold text-left"
@@ -302,7 +313,11 @@ export default function RelationStarModal({
                           <div className="flex w-full items-center justify-between rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-900 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700">
                             <span className="truncate">
                               {selectedSnapshot
-                                ? `${new Date(selectedSnapshot.createdAt).toLocaleDateString()} - ${selectedSnapshot.starScore.toFixed(1)}/10 (${selectedSnapshot.relationshipLabel})`
+                                ? `${new Date(
+                                    selectedSnapshot.createdAt,
+                                  ).toLocaleDateString()} - ${selectedSnapshot.starScore.toFixed(
+                                    1,
+                                  )}/10 (${selectedSnapshot.relationshipLabel})`
                                 : 'Select a snapshot'}
                             </span>
                             <ChevronDown className="ml-2 h-4 w-4 flex-shrink-0" />
@@ -324,10 +339,13 @@ export default function RelationStarModal({
                             >
                               <div className="flex items-center justify-between gap-3 w-full">
                                 <span className="font-medium">
-                                  {new Date(snapshot.createdAt).toLocaleDateString()}
+                                  {new Date(
+                                    snapshot.createdAt,
+                                  ).toLocaleDateString()}
                                 </span>
                                 <span className="text-xs opacity-75 whitespace-nowrap">
-                                  {snapshot.starScore.toFixed(1)}/10 · {snapshot.relationshipLabel}
+                                  {snapshot.starScore.toFixed(1)}/10 ·{' '}
+                                  {snapshot.relationshipLabel}
                                 </span>
                               </div>
                             </DropdownItem>
@@ -340,7 +358,7 @@ export default function RelationStarModal({
                           className="w-full sm:w-auto flex items-center justify-center gap-2 rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-indigo-700 whitespace-nowrap"
                         >
                           <Plus className="h-4 w-4" />
-                          New Cosmic Insights
+                          New
                         </button>
                       )}
                     </div>
@@ -364,637 +382,152 @@ export default function RelationStarModal({
                     <div className="grid gap-8 lg:grid-cols-2">
                       {/* Left: Sliders */}
                       <div>
-                      {/* Collapsible Sliders Section */}
-                      <div className="mb-6">
-                        <button
-                          onClick={() =>
-                            setIsSlidersCollapsed(!isSlidersCollapsed)
-                          }
-                          className="mb-4 flex w-full items-center justify-between text-xl font-semibold text-gray-900 hover:text-indigo-600 dark:text-gray-100 dark:hover:text-indigo-400"
-                        >
-                          <span>Map the Relationship</span>
-                          {isSlidersCollapsed ? (
-                            <ChevronDown className="h-4 w-4" />
-                          ) : (
-                            <ChevronUp className="h-4 w-4" />
-                          )}
-                        </button>
+                        {/* Collapsible Sliders Section */}
+                        <div className="mb-6">
+                          <button
+                            onClick={() =>
+                              setIsSlidersCollapsed(!isSlidersCollapsed)
+                            }
+                            className="mb-4 flex w-full items-center justify-between text-xl font-semibold text-gray-900 hover:text-indigo-600 dark:text-gray-100 dark:hover:text-indigo-400"
+                          >
+                            <span>Map the Relationship</span>
+                            {isSlidersCollapsed ? (
+                              <ChevronDown className="h-4 w-4" />
+                            ) : (
+                              <ChevronUp className="h-4 w-4" />
+                            )}
+                          </button>
 
-                        {!isSlidersCollapsed && (
-                          <div className="space-y-6">
-                            <p className="mb-6 text-sm text-gray-700 dark:text-gray-300">
-                              Map your relationship in the stars and get cosmic
-                              insights.
-                            </p>
+                          {!isSlidersCollapsed && (
+                            <div className="space-y-6">
+                              <p className="mb-6 text-sm text-gray-700 dark:text-gray-300">
+                                Map your relationship in the stars and get
+                                cosmic insights.
+                              </p>
 
-                            {[
-                              {
-                                key: 'proximity',
-                                label: '⭐ How often are you near this person?',
-                                hint: 'Physical and/or virtual proximity',
-                                minLabel: 'Never',
-                                maxLabel: 'Daily',
-                              },
-                              {
-                                key: 'commonGround',
-                                label:
-                                  '⭐ How much common ground do you share?',
-                                hint: 'Interests, values, experiences',
-                                minLabel: 'None',
-                                maxLabel: 'A lot',
-                              },
-                              {
-                                key: 'familiarity',
-                                label: '⭐ How well do you know them?',
-                                hint: 'From name recognition to deep understanding',
-                                minLabel: 'Not at all',
-                                maxLabel: 'Very well',
-                              },
-                              {
-                                key: 'interest',
-                                label:
-                                  '⭐ How interested are you in this relationship?',
-                                hint: 'Desire, ability, commitment',
-                                minLabel: 'Not at all',
-                                maxLabel: 'Very interested',
-                              },
-                              {
-                                key: 'personalTime',
-                                label:
-                                  '⭐  How much personal time do you spend together?',
-                                hint: 'Time together focused on each other in spaces where you can talk freely, not formal/bigger gatherings or doing required tasks',
-                                minLabel: 'None',
-                                maxLabel: 'A lot',
-                              },
-                            ].map(
-                              ({ key, label, hint, minLabel, maxLabel }) => (
-                                <div key={key}>
-                                  <div className="mb-2 flex items-start justify-between gap-4">
-                                    <div className="flex-1">
-                                      <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                                        {label}
-                                      </label>
-                                      <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                                        {hint}
+                              {[
+                                {
+                                  key: 'proximity',
+                                  label:
+                                    '⭐ How often are you near this person?',
+                                  hint: 'Physical and/or virtual proximity',
+                                  minLabel: 'Never',
+                                  maxLabel: 'Daily',
+                                },
+                                {
+                                  key: 'commonGround',
+                                  label:
+                                    '⭐ How much common ground do you share?',
+                                  hint: 'Interests, values, experiences',
+                                  minLabel: 'None',
+                                  maxLabel: 'A lot',
+                                },
+                                {
+                                  key: 'familiarity',
+                                  label: '⭐ How well do you know them?',
+                                  hint: 'From name recognition to deep understanding',
+                                  minLabel: 'Not at all',
+                                  maxLabel: 'Very well',
+                                },
+                                {
+                                  key: 'interest',
+                                  label:
+                                    '⭐ How interested are you in this relationship?',
+                                  hint: 'Desire, ability, commitment',
+                                  minLabel: 'Not at all',
+                                  maxLabel: 'Very interested',
+                                },
+                                {
+                                  key: 'personalTime',
+                                  label:
+                                    '⭐  How much personal time do you spend together?',
+                                  hint: 'Time together focused on each other in spaces where you can talk freely, not formal/bigger gatherings or doing required tasks',
+                                  minLabel: 'None',
+                                  maxLabel: 'A lot',
+                                },
+                              ].map(
+                                ({ key, label, hint, minLabel, maxLabel }) => (
+                                  <div key={key}>
+                                    <div className="mb-2 flex items-start justify-between gap-4">
+                                      <div className="flex-1">
+                                        <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                          {label}
+                                        </label>
+                                        <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                          {hint}
+                                        </div>
                                       </div>
+                                      <span className="flex-shrink-0 text-lg font-bold text-indigo-700 dark:text-indigo-300">
+                                        {
+                                          interactiveScores[
+                                            key as keyof typeof interactiveScores
+                                          ]
+                                        }
+                                      </span>
                                     </div>
-                                    <span className="flex-shrink-0 text-lg font-bold text-indigo-700 dark:text-indigo-300">
-                                      {
+                                    <input
+                                      type="range"
+                                      min="0"
+                                      max="10"
+                                      value={
                                         interactiveScores[
                                           key as keyof typeof interactiveScores
                                         ]
                                       }
-                                    </span>
-                                  </div>
-                                  <input
-                                    type="range"
-                                    min="0"
-                                    max="10"
-                                    value={
-                                      interactiveScores[
-                                        key as keyof typeof interactiveScores
-                                      ]
-                                    }
-                                    onChange={(e) =>
-                                      handleSliderChange(
-                                        key as keyof typeof interactiveScores,
-                                        parseInt(e.target.value),
-                                      )
-                                    }
-                                    className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 dark:bg-gray-700 [&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5 [&::-moz-range-thumb]:appearance-none [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-indigo-600 [&::-moz-range-thumb]:dark:bg-indigo-400 [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-indigo-600 [&::-webkit-slider-thumb]:dark:bg-indigo-400"
-                                  />
-                                  <div className="mt-1 flex justify-between text-xs text-gray-500 dark:text-gray-400">
-                                    <span>0 - {minLabel}</span>
-                                    <span>10 - {maxLabel}</span>
-                                  </div>
-                                </div>
-                              ),
-                            )}
-                          </div>
-                        )}
-                      </div>
-
-                      {/* Relationship Goals */}
-                      <div className="mt-8">
-                        <h3 className="mb-4 text-xl font-bold">
-                          Cosmic Insights
-                        </h3>
-                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                          Relationship context
-                        </label>
-                        <div className="mt-1 mb-2 text-xs text-gray-500 dark:text-gray-400">
-                          Provide relationship context (status, dynamics, hopes,
-                          etc.) for personalized insights.
-                        </div>
-                        <textarea
-                          value={relationshipGoals}
-                          onChange={(e) => setRelationshipGoals(e.target.value)}
-                          placeholder={`e.g., I'd like to feel closer to ${memberName}, or I want to maintain this friendship despite living far apart...`}
-                          maxLength={500}
-                          rows={3}
-                          className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-500"
-                        />
-                        <div className="text-right text-xs text-gray-500 dark:text-gray-400">
-                          {relationshipGoals.length}/500 characters
-                        </div>
-                      </div>
-
-                      {/* Privacy Notice - Only show when at least one slider has a value */}
-                      {!Object.values(interactiveScores).every(
-                        (v) => v === 0,
-                      ) && (
-                        <div className="mt-6 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800">
-                          <div className="flex items-start gap-2">
-                            <svg
-                              className="h-5 w-5 flex-shrink-0 text-gray-600 dark:text-gray-400"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
-                              />
-                            </svg>
-                            <div className="text-xs text-gray-700 dark:text-gray-300">
-                              <strong className="font-semibold">
-                                Your privacy matters.
-                              </strong>{' '}
-                              Your responses and AI insights are completely
-                              private and only visible to you.
-                            </div>
-                          </div>
-                        </div>
-                      )}
-
-                      {/* AI Assessment Button - Only show when at least one slider has a value */}
-                      {!Object.values(interactiveScores).every(
-                        (v) => v === 0,
-                      ) && (
-                        <div className="mt-6">
-                          <button
-                            onClick={
-                              aiInsight ? handleStartOver : handleAIAssessment
-                            }
-                            disabled={!aiInsight && isLoadingAI}
-                            className="w-full rounded-lg bg-indigo-600 px-4 py-3 text-sm font-medium text-white transition-colors hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-500 dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
-                          >
-                            {aiInsight ? (
-                              'Start Over'
-                            ) : isLoadingAI ? (
-                              <span className="flex items-center justify-center gap-2">
-                                <svg
-                                  className="h-4 w-4 animate-spin"
-                                  viewBox="0 0 24 24"
-                                >
-                                  <circle
-                                    className="opacity-25"
-                                    cx="12"
-                                    cy="12"
-                                    r="10"
-                                    stroke="currentColor"
-                                    strokeWidth="4"
-                                    fill="none"
-                                  />
-                                  <path
-                                    className="opacity-75"
-                                    fill="currentColor"
-                                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                                  />
-                                </svg>
-                                Gathering wisdom...
-                              </span>
-                            ) : (
-                              'Get Cosmic Insights'
-                            )}
-                          </button>
-
-                          {aiError && (
-                            <div className="mt-3 rounded-lg bg-red-50 p-3 text-sm text-red-800 dark:bg-red-900/20 dark:text-red-200">
-                              {aiError}
-                            </div>
-                          )}
-
-                          {aiInsight && (
-                            <>
-                              {/* Divider before AI Insights */}
-                              <div className="my-6 border-t-2 border-gray-300 dark:border-gray-600" />
-
-                              <div className="rounded-lg border border-indigo-200 bg-indigo-50 p-6 dark:border-indigo-900 dark:bg-indigo-950">
-                                <div className="mb-4 flex items-center justify-between">
-                                  <h4 className="text-lg font-semibold text-indigo-900 dark:text-indigo-100">
-                                    Cosmic Insights from the Stars
-                                  </h4>
-                                  {currentAssessmentId && (
-                                    <button
-                                      onClick={() =>
-                                        window.open(
-                                          `/cosmic-insights/${currentAssessmentId}`,
-                                          '_blank'
+                                      onChange={(e) =>
+                                        handleSliderChange(
+                                          key as keyof typeof interactiveScores,
+                                          parseInt(e.target.value),
                                         )
                                       }
-                                      className="flex items-center gap-2 rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-indigo-700"
-                                    >
-                                      <svg
-                                        className="h-4 w-4"
-                                        fill="none"
-                                        viewBox="0 0 24 24"
-                                        stroke="currentColor"
-                                      >
-                                        <path
-                                          strokeLinecap="round"
-                                          strokeLinejoin="round"
-                                          strokeWidth={2}
-                                          d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                                        />
-                                      </svg>
-                                      Full Page
-                                    </button>
-                                  )}
-                                </div>
-                                <div
-                                  className="prose prose-sm prose-indigo dark:prose-invert max-w-none text-indigo-800 dark:text-indigo-200 [&_li]:leading-relaxed [&_ul]:space-y-3 [&>div]:space-y-2 [&>p]:mb-4"
-                                  dangerouslySetInnerHTML={{
-                                    __html: aiInsight,
-                                  }}
-                                />
-                              </div>
-                            </>
+                                      className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 dark:bg-gray-700 [&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5 [&::-moz-range-thumb]:appearance-none [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-indigo-600 [&::-moz-range-thumb]:dark:bg-indigo-400 [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-indigo-600 [&::-webkit-slider-thumb]:dark:bg-indigo-400"
+                                    />
+                                    <div className="mt-1 flex justify-between text-xs text-gray-500 dark:text-gray-400">
+                                      <span>0 - {minLabel}</span>
+                                      <span>10 - {maxLabel}</span>
+                                    </div>
+                                  </div>
+                                ),
+                              )}
+                            </div>
                           )}
                         </div>
-                      )}
-                    </div>
 
-                    {/* Right: Chart and Score */}
-                    <div className="space-y-6">
-                      {/* Mini Chart */}
-                      <div className="rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
-                        <h3 className="mb-4 text-xl font-bold">Star Chart</h3>
-                        <div className="relative mx-auto aspect-square w-full">
-                          <svg
-                            viewBox="-10 -10 340 340"
-                            className="h-full w-full"
-                          >
-                            {/* Center point */}
-                            <circle cx="160" cy="160" r="3" fill="#4f46e5" />
-
-                            {/* Concentric circles */}
-                            {[32, 64, 96, 128, 160].map((radius) => (
-                              <circle
-                                key={radius}
-                                cx="160"
-                                cy="160"
-                                r={radius}
-                                fill="none"
-                                stroke="currentColor"
-                                strokeWidth="1"
-                                className="stroke-gray-300 dark:stroke-gray-600"
-                              />
-                            ))}
-
-                            {/* Scale labels (0, 5, 10) straight up from center */}
-                            {[0, 5, 10].map((val) => (
-                              <text
-                                key={val}
-                                x="160"
-                                y={160 - val * 16 - (val === 0 ? 12 : 0) + 5}
-                                textAnchor="middle"
-                                fontSize="14"
-                                fontWeight="500"
-                                fill="currentColor"
-                                className="fill-gray-600 dark:fill-gray-400"
-                              >
-                                {val}
-                              </text>
-                            ))}
-
-                            {/* Axes */}
-                            {[
-                              { key: 'proximity', label: 'Proximity' },
-                              { key: 'interest', label: 'Interest' },
-                              { key: 'personalTime', label: 'Personal Time' },
-                              { key: 'commonGround', label: 'Common Ground' },
-                              { key: 'familiarity', label: 'Familiarity' },
-                            ].map((_, idx) => {
-                              const angle =
-                                (idx * (360 / 5) - 90 + 30) * (Math.PI / 180)
-                              const x = 160 + 160 * Math.cos(angle)
-                              const y = 160 + 160 * Math.sin(angle)
-                              return (
-                                <line
-                                  key={idx}
-                                  x1="160"
-                                  y1="160"
-                                  x2={x}
-                                  y2={y}
-                                  stroke="currentColor"
-                                  strokeWidth="1"
-                                  className="stroke-gray-300 dark:stroke-gray-600"
-                                />
-                              )
-                            })}
-
-                            {/* Filled area */}
-                            <path
-                              d={
-                                [
-                                  {
-                                    key: 'proximity',
-                                    value: interactiveScores.proximity,
-                                  },
-                                  {
-                                    key: 'interest',
-                                    value: interactiveScores.interest,
-                                  },
-                                  {
-                                    key: 'personalTime',
-                                    value: interactiveScores.personalTime,
-                                  },
-                                  {
-                                    key: 'commonGround',
-                                    value: interactiveScores.commonGround,
-                                  },
-                                  {
-                                    key: 'familiarity',
-                                    value: interactiveScores.familiarity,
-                                  },
-                                ]
-                                  .map((item, idx) => {
-                                    const angle =
-                                      (idx * (360 / 5) - 90 + 30) *
-                                      (Math.PI / 180)
-                                    const length = item.value * 16
-                                    const x = 160 + length * Math.cos(angle)
-                                    const y = 160 + length * Math.sin(angle)
-                                    return `${idx === 0 ? 'M' : 'L'} ${x} ${y}`
-                                  })
-                                  .join(' ') + ' Z'
-                              }
-                              fill="#4f46e5"
-                              fillOpacity="0.15"
-                              stroke="#4f46e5"
-                              strokeWidth="3"
-                              opacity="0.6"
-                            />
-
-                            {/* Points */}
-                            {[
-                              {
-                                key: 'proximity',
-                                value: interactiveScores.proximity,
-                                dimension: 'Proximity',
-                              },
-                              {
-                                key: 'interest',
-                                value: interactiveScores.interest,
-                                dimension: 'Interest',
-                              },
-                              {
-                                key: 'personalTime',
-                                value: interactiveScores.personalTime,
-                                dimension: 'Personal Time',
-                              },
-                              {
-                                key: 'commonGround',
-                                value: interactiveScores.commonGround,
-                                dimension: 'Common Ground',
-                              },
-                              {
-                                key: 'familiarity',
-                                value: interactiveScores.familiarity,
-                                dimension: 'Familiarity',
-                              },
-                            ].map((item, idx) => {
-                              const angle =
-                                (idx * (360 / 5) - 90 + 30) * (Math.PI / 180)
-                              const length = item.value * 16
-                              // No offset needed now that chart is rotated away from edges
-                              const offset = 0
-                              const x =
-                                160 + (length + offset) * Math.cos(angle)
-                              const y =
-                                160 + (length + offset) * Math.sin(angle)
-
-                              return (
-                                <g key={idx}>
-                                  {/* Dots - drawn before labels */}
-                                  <circle
-                                    cx={x}
-                                    cy={y}
-                                    r="8"
-                                    fill="#4f46e5"
-                                    opacity="0.3"
-                                  />
-                                  <circle cx={x} cy={y} r="4" fill="#4f46e5" />
-                                  {/* Twinkle effect - white flash */}
-                                  <circle
-                                    cx={x}
-                                    cy={y}
-                                    r="3"
-                                    fill="white"
-                                    opacity="0"
-                                  >
-                                    <animate
-                                      attributeName="opacity"
-                                      values="0;0;0.8;0;0"
-                                      dur="2.5s"
-                                      repeatCount="indefinite"
-                                      begin={`${idx * 0.5}s`}
-                                    />
-                                  </circle>
-
-                                  {/* Labels - always show, with smart positioning */}
-                                  {(() => {
-                                    // Use a smaller distance to keep labels within viewBox
-                                    const labelDistance = 145
-                                    const labelX =
-                                      160 + labelDistance * Math.cos(angle)
-                                    const labelY =
-                                      160 + labelDistance * Math.sin(angle)
-
-                                    return (
-                                      <>
-                                        {item.dimension === 'Personal Time' ? (
-                                          <>
-                                            <text
-                                              x={labelX}
-                                              y={labelY - 6}
-                                              textAnchor="middle"
-                                              fontSize="14"
-                                              fontWeight="600"
-                                              fill="currentColor"
-                                              className="fill-gray-900 dark:fill-gray-100"
-                                            >
-                                              Personal
-                                            </text>
-                                            <text
-                                              x={labelX}
-                                              y={labelY + 6}
-                                              textAnchor="middle"
-                                              fontSize="14"
-                                              fontWeight="600"
-                                              fill="currentColor"
-                                              className="fill-gray-900 dark:fill-gray-100"
-                                            >
-                                              Time
-                                            </text>
-                                          </>
-                                        ) : item.dimension ===
-                                          'Common Ground' ? (
-                                          <>
-                                            <text
-                                              x={labelX}
-                                              y={labelY - 6}
-                                              textAnchor="middle"
-                                              fontSize="14"
-                                              fontWeight="600"
-                                              fill="currentColor"
-                                              className="fill-gray-900 dark:fill-gray-100"
-                                            >
-                                              Common
-                                            </text>
-                                            <text
-                                              x={labelX}
-                                              y={labelY + 6}
-                                              textAnchor="middle"
-                                              fontSize="14"
-                                              fontWeight="600"
-                                              fill="currentColor"
-                                              className="fill-gray-900 dark:fill-gray-100"
-                                            >
-                                              Ground
-                                            </text>
-                                          </>
-                                        ) : (
-                                          <text
-                                            x={labelX}
-                                            y={labelY}
-                                            textAnchor="middle"
-                                            fontSize="14"
-                                            fontWeight="600"
-                                            fill="currentColor"
-                                            className="fill-gray-900 dark:fill-gray-100"
-                                          >
-                                            {item.dimension}
-                                          </text>
-                                        )}
-                                      </>
-                                    )
-                                  })()}
-                                </g>
-                              )
-                            })}
-                          </svg>
-                        </div>
-                      </div>
-
-                      {/* Divider */}
-                      <div className="border-t border-gray-200 dark:border-gray-700" />
-
-                      {/* Star Score */}
-                      <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
-                        <h3 className="mb-4 text-xl font-bold">Star Score</h3>
-                        <div className="mb-4 text-center">
-                          <div className="font-bold">
-                            <span className="text-4xl text-indigo-600 dark:text-indigo-400">
-                              {starScore.toFixed(1)}
-                            </span>
-                            <span className="text-2xl text-gray-400 dark:text-gray-600">
-                              /10
-                            </span>
-                          </div>
-                          <div className="text-sm text-gray-600 dark:text-gray-400">
-                            {starScore >= 8
-                              ? 'Close Friend'
-                              : starScore >= 5
-                              ? 'Friend'
-                              : starScore >= 3
-                              ? 'Acquaintance'
-                              : starScore >= 1
-                              ? 'Nodding Acquaintance'
-                              : 'Stranger'}
-                          </div>
-                        </div>
-                        <div className="space-y-2 text-sm">
-                          <div className="flex justify-between">
-                            <span className="text-gray-600 dark:text-gray-400">
-                              Personal Time (30%)
-                            </span>
-                            <span className="font-medium">
-                              {interactiveScores.personalTime}/10
-                            </span>
-                          </div>
-                          <div className="flex justify-between">
-                            <span className="text-gray-600 dark:text-gray-400">
-                              Common Ground (25%)
-                            </span>
-                            <span className="font-medium">
-                              {interactiveScores.commonGround}/10
-                            </span>
-                          </div>
-                          <div className="flex justify-between">
-                            <span className="text-gray-600 dark:text-gray-400">
-                              Familiarity (20%)
-                            </span>
-                            <span className="font-medium">
-                              {interactiveScores.familiarity}/10
-                            </span>
-                          </div>
-                          <div className="flex justify-between">
-                            <span className="text-gray-600 dark:text-gray-400">
-                              Interest (15%)
-                            </span>
-                            <span className="font-medium">
-                              {interactiveScores.interest}/10
-                            </span>
-                          </div>
-                          <div className="flex justify-between">
-                            <span className="text-gray-600 dark:text-gray-400">
-                              Proximity (10%)
-                            </span>
-                            <span className="font-medium">
-                              {interactiveScores.proximity}/10
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                ) : selectedSnapshot ? (
-                  // Read-only mode - show historical snapshot
-                  <div className="grid gap-8 lg:grid-cols-2">
-                    {/* Left: Saved Context and AI Response */}
-                    <div className="space-y-6">
-                      {selectedSnapshot.relationshipGoals && (
-                        <div>
+                        {/* Relationship Goals */}
+                        <div className="mt-8">
                           <h3 className="mb-4 text-xl font-bold">
-                            Relationship Context
+                            Cosmic Insights
                           </h3>
-                          <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
-                            {selectedSnapshot.relationshipGoals}
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                            Relationship context
+                          </label>
+                          <div className="mt-1 mb-2 text-xs text-gray-500 dark:text-gray-400">
+                            Provide relationship context (status, dynamics,
+                            hopes, etc.) for personalized insights.
+                          </div>
+                          <textarea
+                            value={relationshipGoals}
+                            onChange={(e) =>
+                              setRelationshipGoals(e.target.value)
+                            }
+                            placeholder={`e.g., I'd like to feel closer to ${memberName}, or I want to maintain this friendship despite living far apart...`}
+                            maxLength={500}
+                            rows={3}
+                            className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-500"
+                          />
+                          <div className="text-right text-xs text-gray-500 dark:text-gray-400">
+                            {relationshipGoals.length}/500 characters
                           </div>
                         </div>
-                      )}
 
-                      <div>
-                        <div className="rounded-lg border border-indigo-200 bg-indigo-50 p-6 dark:border-indigo-900 dark:bg-indigo-950">
-                          <div className="mb-4 flex items-center justify-between">
-                            <h3 className="text-xl font-bold text-indigo-900 dark:text-indigo-100">
-                              Cosmic Insights from the Stars
-                            </h3>
-                            <button
-                              onClick={() =>
-                                window.open(
-                                  `/cosmic-insights/${selectedSnapshot.id}`,
-                                  '_blank'
-                                )
-                              }
-                              className="flex items-center gap-2 rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-indigo-700"
-                            >
+                        {/* Privacy Notice - Only show when at least one slider has a value */}
+                        {!Object.values(interactiveScores).every(
+                          (v) => v === 0,
+                        ) && (
+                          <div className="mt-6 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800">
+                            <div className="flex items-start gap-2">
                               <svg
-                                className="h-4 w-4"
+                                className="h-5 w-5 flex-shrink-0 text-gray-600 dark:text-gray-400"
                                 fill="none"
                                 viewBox="0 0 24 24"
                                 stroke="currentColor"
@@ -1003,234 +536,744 @@ export default function RelationStarModal({
                                   strokeLinecap="round"
                                   strokeLinejoin="round"
                                   strokeWidth={2}
-                                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                                  d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
                                 />
                               </svg>
-                              Full Page
-                            </button>
+                              <div className="text-xs text-gray-700 dark:text-gray-300">
+                                <strong className="font-semibold">
+                                  Your privacy matters.
+                                </strong>{' '}
+                                Your responses and AI insights are completely
+                                private and only visible to you.
+                              </div>
+                            </div>
                           </div>
-                          <div
-                            className="prose prose-sm prose-indigo dark:prose-invert max-w-none text-indigo-800 dark:text-indigo-200 [&_li]:leading-relaxed [&_ul]:space-y-3 [&>div]:space-y-2 [&>p]:mb-4"
-                            dangerouslySetInnerHTML={{
-                              __html: selectedSnapshot.response,
-                            }}
-                          />
-                        </div>
+                        )}
+
+                        {/* AI Assessment Button - Only show when at least one slider has a value */}
+                        {!Object.values(interactiveScores).every(
+                          (v) => v === 0,
+                        ) && (
+                          <div className="mt-6">
+                            <button
+                              onClick={
+                                aiInsight ? handleStartOver : handleAIAssessment
+                              }
+                              disabled={!aiInsight && isLoadingAI}
+                              className="w-full rounded-lg bg-indigo-600 px-4 py-3 text-sm font-medium text-white transition-colors hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-500 dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
+                            >
+                              {aiInsight ? (
+                                'Start Over'
+                              ) : isLoadingAI ? (
+                                <span className="flex items-center justify-center gap-2">
+                                  <svg
+                                    className="h-4 w-4 animate-spin"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <circle
+                                      className="opacity-25"
+                                      cx="12"
+                                      cy="12"
+                                      r="10"
+                                      stroke="currentColor"
+                                      strokeWidth="4"
+                                      fill="none"
+                                    />
+                                    <path
+                                      className="opacity-75"
+                                      fill="currentColor"
+                                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                                    />
+                                  </svg>
+                                  Gathering wisdom...
+                                </span>
+                              ) : (
+                                'Get Cosmic Insights'
+                              )}
+                            </button>
+
+                            {aiError && (
+                              <div className="mt-3 rounded-lg bg-red-50 p-3 text-sm text-red-800 dark:bg-red-900/20 dark:text-red-200">
+                                {aiError}
+                              </div>
+                            )}
+
+                            {aiInsight && (
+                              <>
+                                {/* Divider before AI Insights */}
+                                <div className="my-6 border-t-2 border-gray-300 dark:border-gray-600" />
+
+                                <div className="rounded-lg border border-indigo-200 bg-indigo-50 p-6 dark:border-indigo-900 dark:bg-indigo-950">
+                                  <div className="mb-4 flex items-center justify-between">
+                                    <h4 className="text-lg font-semibold text-indigo-900 dark:text-indigo-100">
+                                      Cosmic Insights from the Stars
+                                    </h4>
+                                    {currentAssessmentId && (
+                                      <button
+                                        onClick={() =>
+                                          window.open(
+                                            `/cosmic-insights/${currentAssessmentId}`,
+                                            '_blank',
+                                          )
+                                        }
+                                        className="flex items-center gap-2 rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-indigo-700"
+                                      >
+                                        <svg
+                                          className="h-4 w-4"
+                                          fill="none"
+                                          viewBox="0 0 24 24"
+                                          stroke="currentColor"
+                                        >
+                                          <path
+                                            strokeLinecap="round"
+                                            strokeLinejoin="round"
+                                            strokeWidth={2}
+                                            d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                                          />
+                                        </svg>
+                                        Full Page
+                                      </button>
+                                    )}
+                                  </div>
+                                  <div
+                                    className="prose prose-sm prose-indigo dark:prose-invert max-w-none text-indigo-800 dark:text-indigo-200 [&_li]:leading-relaxed [&_ul]:space-y-3 [&>div]:space-y-2 [&>p]:mb-4"
+                                    dangerouslySetInnerHTML={{
+                                      __html: aiInsight,
+                                    }}
+                                  />
+                                </div>
+                              </>
+                            )}
+                          </div>
+                        )}
                       </div>
-                    </div>
 
-                    {/* Right: Chart and Score */}
-                    <div className="space-y-6">
-                      {/* Star Chart */}
-                      <div className="rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
-                        <h3 className="mb-4 text-xl font-bold">Star Chart</h3>
-                        <div className="relative mx-auto aspect-square w-full">
-                          <svg
-                            viewBox="-10 -10 340 340"
-                            className="h-full w-full"
-                          >
-                            {/* Center point */}
-                            <circle cx="160" cy="160" r="3" fill="#4f46e5" />
+                      {/* Right: Chart and Score */}
+                      <div className="space-y-6">
+                        {/* Mini Chart */}
+                        <div className="rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+                          <h3 className="mb-4 text-xl font-bold">Star Chart</h3>
+                          <div className="relative mx-auto aspect-square w-full">
+                            <svg
+                              viewBox="-10 -10 340 340"
+                              className="h-full w-full"
+                            >
+                              {/* Center point */}
+                              <circle cx="160" cy="160" r="3" fill="#4f46e5" />
 
-                            {/* Concentric circles */}
-                            {[32, 64, 96, 128, 160].map((radius) => (
-                              <circle
-                                key={radius}
-                                cx="160"
-                                cy="160"
-                                r={radius}
-                                fill="none"
-                                stroke="currentColor"
-                                strokeWidth="1"
-                                className="stroke-gray-300 dark:stroke-gray-600"
-                              />
-                            ))}
-
-                            {/* Scale labels */}
-                            {[0, 5, 10].map((val) => (
-                              <text
-                                key={val}
-                                x="160"
-                                y={160 - val * 16 - (val === 0 ? 12 : 0) + 5}
-                                textAnchor="middle"
-                                fontSize="14"
-                                fontWeight="500"
-                                fill="currentColor"
-                                className="fill-gray-500 dark:fill-gray-400"
-                              >
-                                {val}
-                              </text>
-                            ))}
-
-                            {/* Axes */}
-                            {Object.keys(selectedSnapshot.scores).map((_, idx) => {
-                              const angle =
-                                (idx * (360 / 5) - 90 + 30) * (Math.PI / 180)
-                              const x = 160 + 160 * Math.cos(angle)
-                              const y = 160 + 160 * Math.sin(angle)
-                              return (
-                                <line
-                                  key={idx}
-                                  x1="160"
-                                  y1="160"
-                                  x2={x}
-                                  y2={y}
+                              {/* Concentric circles */}
+                              {[32, 64, 96, 128, 160].map((radius) => (
+                                <circle
+                                  key={radius}
+                                  cx="160"
+                                  cy="160"
+                                  r={radius}
+                                  fill="none"
                                   stroke="currentColor"
                                   strokeWidth="1"
                                   className="stroke-gray-300 dark:stroke-gray-600"
                                 />
-                              )
-                            })}
+                              ))}
 
-                            {/* Filled area */}
-                            <path
-                              d={
-                                Object.values(selectedSnapshot.scores)
-                                  .map((value: number, idx) => {
-                                    const angle =
-                                      (idx * (360 / 5) - 90 + 30) *
-                                      (Math.PI / 180)
-                                    const length = value * 16
-                                    const x = 160 + length * Math.cos(angle)
-                                    const y = 160 + length * Math.sin(angle)
-                                    return `${idx === 0 ? 'M' : 'L'} ${x} ${y}`
-                                  })
-                                  .join(' ') + ' Z'
-                              }
-                              fill="#4f46e5"
-                              fillOpacity="0.15"
-                              stroke="#4f46e5"
-                              strokeWidth="3"
-                              opacity="0.6"
-                            />
+                              {/* Scale labels (0, 5, 10) straight up from center */}
+                              {[0, 5, 10].map((val) => (
+                                <text
+                                  key={val}
+                                  x="160"
+                                  y={160 - val * 16 - (val === 0 ? 12 : 0) + 5}
+                                  textAnchor="middle"
+                                  fontSize="14"
+                                  fontWeight="500"
+                                  fill="currentColor"
+                                  className="fill-gray-600 dark:fill-gray-400"
+                                >
+                                  {val}
+                                </text>
+                              ))}
 
-                            {/* Points */}
-                            {Object.values(selectedSnapshot.scores).map(
-                              (value: number, idx) => {
+                              {/* Axes */}
+                              {[
+                                { key: 'proximity', label: 'Proximity' },
+                                { key: 'interest', label: 'Interest' },
+                                { key: 'personalTime', label: 'Personal Time' },
+                                { key: 'commonGround', label: 'Common Ground' },
+                                { key: 'familiarity', label: 'Familiarity' },
+                              ].map((_, idx) => {
                                 const angle =
                                   (idx * (360 / 5) - 90 + 30) * (Math.PI / 180)
-                                const length = value * 16
-                                const x = 160 + length * Math.cos(angle)
-                                const y = 160 + length * Math.sin(angle)
+                                const x = 160 + 160 * Math.cos(angle)
+                                const y = 160 + 160 * Math.sin(angle)
+                                return (
+                                  <line
+                                    key={idx}
+                                    x1="160"
+                                    y1="160"
+                                    x2={x}
+                                    y2={y}
+                                    stroke="currentColor"
+                                    strokeWidth="1"
+                                    className="stroke-gray-300 dark:stroke-gray-600"
+                                  />
+                                )
+                              })}
+
+                              {/* Filled area */}
+                              <path
+                                d={
+                                  [
+                                    {
+                                      key: 'proximity',
+                                      value: interactiveScores.proximity,
+                                    },
+                                    {
+                                      key: 'interest',
+                                      value: interactiveScores.interest,
+                                    },
+                                    {
+                                      key: 'personalTime',
+                                      value: interactiveScores.personalTime,
+                                    },
+                                    {
+                                      key: 'commonGround',
+                                      value: interactiveScores.commonGround,
+                                    },
+                                    {
+                                      key: 'familiarity',
+                                      value: interactiveScores.familiarity,
+                                    },
+                                  ]
+                                    .map((item, idx) => {
+                                      const angle =
+                                        (idx * (360 / 5) - 90 + 30) *
+                                        (Math.PI / 180)
+                                      const length = item.value * 16
+                                      const x = 160 + length * Math.cos(angle)
+                                      const y = 160 + length * Math.sin(angle)
+                                      return `${
+                                        idx === 0 ? 'M' : 'L'
+                                      } ${x} ${y}`
+                                    })
+                                    .join(' ') + ' Z'
+                                }
+                                fill="#4f46e5"
+                                fillOpacity="0.15"
+                                stroke="#4f46e5"
+                                strokeWidth="3"
+                                opacity="0.6"
+                              />
+
+                              {/* Points */}
+                              {[
+                                {
+                                  key: 'proximity',
+                                  value: interactiveScores.proximity,
+                                  dimension: 'Proximity',
+                                },
+                                {
+                                  key: 'interest',
+                                  value: interactiveScores.interest,
+                                  dimension: 'Interest',
+                                },
+                                {
+                                  key: 'personalTime',
+                                  value: interactiveScores.personalTime,
+                                  dimension: 'Personal Time',
+                                },
+                                {
+                                  key: 'commonGround',
+                                  value: interactiveScores.commonGround,
+                                  dimension: 'Common Ground',
+                                },
+                                {
+                                  key: 'familiarity',
+                                  value: interactiveScores.familiarity,
+                                  dimension: 'Familiarity',
+                                },
+                              ].map((item, idx) => {
+                                const angle =
+                                  (idx * (360 / 5) - 90 + 30) * (Math.PI / 180)
+                                const length = item.value * 16
+                                // No offset needed now that chart is rotated away from edges
+                                const offset = 0
+                                const x =
+                                  160 + (length + offset) * Math.cos(angle)
+                                const y =
+                                  160 + (length + offset) * Math.sin(angle)
 
                                 return (
                                   <g key={idx}>
+                                    {/* Dots - drawn before labels */}
                                     <circle
                                       cx={x}
                                       cy={y}
-                                      r="6"
+                                      r="8"
                                       fill="#4f46e5"
-                                      stroke="white"
-                                      strokeWidth="2"
+                                      opacity="0.3"
                                     />
+                                    <circle
+                                      cx={x}
+                                      cy={y}
+                                      r="4"
+                                      fill="#4f46e5"
+                                    />
+                                    {/* Twinkle effect - white flash */}
+                                    <circle
+                                      cx={x}
+                                      cy={y}
+                                      r="3"
+                                      fill="white"
+                                      opacity="0"
+                                    >
+                                      <animate
+                                        attributeName="opacity"
+                                        values="0;0;0.8;0;0"
+                                        dur="2.5s"
+                                        repeatCount="indefinite"
+                                        begin={`${idx * 0.5}s`}
+                                      />
+                                    </circle>
+
+                                    {/* Labels - always show, with smart positioning */}
+                                    {(() => {
+                                      // Use a smaller distance to keep labels within viewBox
+                                      const labelDistance = 145
+                                      const labelX =
+                                        160 + labelDistance * Math.cos(angle)
+                                      const labelY =
+                                        160 + labelDistance * Math.sin(angle)
+
+                                      return (
+                                        <>
+                                          {item.dimension ===
+                                          'Personal Time' ? (
+                                            <>
+                                              <text
+                                                x={labelX}
+                                                y={labelY - 6}
+                                                textAnchor="middle"
+                                                fontSize="14"
+                                                fontWeight="600"
+                                                fill="currentColor"
+                                                className="fill-gray-900 dark:fill-gray-100"
+                                              >
+                                                Personal
+                                              </text>
+                                              <text
+                                                x={labelX}
+                                                y={labelY + 6}
+                                                textAnchor="middle"
+                                                fontSize="14"
+                                                fontWeight="600"
+                                                fill="currentColor"
+                                                className="fill-gray-900 dark:fill-gray-100"
+                                              >
+                                                Time
+                                              </text>
+                                            </>
+                                          ) : item.dimension ===
+                                            'Common Ground' ? (
+                                            <>
+                                              <text
+                                                x={labelX}
+                                                y={labelY - 6}
+                                                textAnchor="middle"
+                                                fontSize="14"
+                                                fontWeight="600"
+                                                fill="currentColor"
+                                                className="fill-gray-900 dark:fill-gray-100"
+                                              >
+                                                Common
+                                              </text>
+                                              <text
+                                                x={labelX}
+                                                y={labelY + 6}
+                                                textAnchor="middle"
+                                                fontSize="14"
+                                                fontWeight="600"
+                                                fill="currentColor"
+                                                className="fill-gray-900 dark:fill-gray-100"
+                                              >
+                                                Ground
+                                              </text>
+                                            </>
+                                          ) : (
+                                            <text
+                                              x={labelX}
+                                              y={labelY}
+                                              textAnchor="middle"
+                                              fontSize="14"
+                                              fontWeight="600"
+                                              fill="currentColor"
+                                              className="fill-gray-900 dark:fill-gray-100"
+                                            >
+                                              {item.dimension}
+                                            </text>
+                                          )}
+                                        </>
+                                      )
+                                    })()}
                                   </g>
                                 )
-                              },
-                            )}
-
-                            {/* Labels */}
-                            {[
-                              { key: 'proximity', label: 'Proximity' },
-                              { key: 'interest', label: 'Interest' },
-                              { key: 'personalTime', label: 'Personal\nTime' },
-                              { key: 'commonGround', label: 'Common\nGround' },
-                              { key: 'familiarity', label: 'Familiarity' },
-                            ].map((dim, idx) => {
-                              const angle =
-                                (idx * (360 / 5) - 90 + 30) * (Math.PI / 180)
-                              const labelDistance = 145
-                              const x = 160 + labelDistance * Math.cos(angle)
-                              const y = 160 + labelDistance * Math.sin(angle)
-
-                              return (
-                                <text
-                                  key={dim.key}
-                                  x={x}
-                                  y={y}
-                                  textAnchor="middle"
-                                  dominantBaseline="middle"
-                                  fontSize="14"
-                                  fontWeight="600"
-                                  fill="currentColor"
-                                  className="fill-gray-700 dark:fill-gray-300"
-                                >
-                                  {dim.label.split('\n').map((line, i) => (
-                                    <tspan
-                                      key={i}
-                                      x={x}
-                                      dy={i === 0 ? 0 : 16}
-                                    >
-                                      {line}
-                                    </tspan>
-                                  ))}
-                                </text>
-                              )
-                            })}
-                          </svg>
-                        </div>
-                      </div>
-
-                      {/* Star Score */}
-                      <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
-                        <h3 className="mb-4 text-xl font-bold">Star Score</h3>
-                        <div className="mb-4 text-center">
-                          <div className="font-bold">
-                            <span className="text-4xl text-indigo-600 dark:text-indigo-400">
-                              {selectedSnapshot.starScore.toFixed(1)}
-                            </span>
-                            <span className="text-2xl text-gray-400">/10</span>
-                          </div>
-                          <div className="mt-2 text-sm font-medium text-gray-600 dark:text-gray-400">
-                            {selectedSnapshot.relationshipLabel}
+                              })}
+                            </svg>
                           </div>
                         </div>
 
-                        <div className="space-y-2 text-sm">
-                          <div className="flex justify-between">
-                            <span className="text-gray-600 dark:text-gray-400">
-                              Personal Time (30%)
-                            </span>
-                            <span className="font-medium">
-                              {selectedSnapshot.scores.personalTime}/10
-                            </span>
+                        {/* Divider */}
+                        <div className="border-t border-gray-200 dark:border-gray-700" />
+
+                        {/* Star Score */}
+                        <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+                          <h3 className="mb-4 text-xl font-bold">Star Score</h3>
+                          <div className="mb-4 text-center">
+                            <div className="font-bold">
+                              <span className="text-4xl text-indigo-600 dark:text-indigo-400">
+                                {starScore.toFixed(1)}
+                              </span>
+                              <span className="text-2xl text-gray-400 dark:text-gray-600">
+                                /10
+                              </span>
+                            </div>
+                            <div className="text-sm text-gray-600 dark:text-gray-400">
+                              {starScore >= 8
+                                ? 'Close Friend'
+                                : starScore >= 5
+                                ? 'Friend'
+                                : starScore >= 3
+                                ? 'Acquaintance'
+                                : starScore >= 1
+                                ? 'Nodding Acquaintance'
+                                : 'Stranger'}
+                            </div>
                           </div>
-                          <div className="flex justify-between">
-                            <span className="text-gray-600 dark:text-gray-400">
-                              Common Ground (25%)
-                            </span>
-                            <span className="font-medium">
-                              {selectedSnapshot.scores.commonGround}/10
-                            </span>
-                          </div>
-                          <div className="flex justify-between">
-                            <span className="text-gray-600 dark:text-gray-400">
-                              Familiarity (20%)
-                            </span>
-                            <span className="font-medium">
-                              {selectedSnapshot.scores.familiarity}/10
-                            </span>
-                          </div>
-                          <div className="flex justify-between">
-                            <span className="text-gray-600 dark:text-gray-400">
-                              Interest (15%)
-                            </span>
-                            <span className="font-medium">
-                              {selectedSnapshot.scores.interest}/10
-                            </span>
-                          </div>
-                          <div className="flex justify-between">
-                            <span className="text-gray-600 dark:text-gray-400">
-                              Proximity (10%)
-                            </span>
-                            <span className="font-medium">
-                              {selectedSnapshot.scores.proximity}/10
-                            </span>
+                          <div className="space-y-2 text-sm">
+                            <div className="flex justify-between">
+                              <span className="text-gray-600 dark:text-gray-400">
+                                Personal Time (30%)
+                              </span>
+                              <span className="font-medium">
+                                {interactiveScores.personalTime}/10
+                              </span>
+                            </div>
+                            <div className="flex justify-between">
+                              <span className="text-gray-600 dark:text-gray-400">
+                                Common Ground (25%)
+                              </span>
+                              <span className="font-medium">
+                                {interactiveScores.commonGround}/10
+                              </span>
+                            </div>
+                            <div className="flex justify-between">
+                              <span className="text-gray-600 dark:text-gray-400">
+                                Familiarity (20%)
+                              </span>
+                              <span className="font-medium">
+                                {interactiveScores.familiarity}/10
+                              </span>
+                            </div>
+                            <div className="flex justify-between">
+                              <span className="text-gray-600 dark:text-gray-400">
+                                Interest (15%)
+                              </span>
+                              <span className="font-medium">
+                                {interactiveScores.interest}/10
+                              </span>
+                            </div>
+                            <div className="flex justify-between">
+                              <span className="text-gray-600 dark:text-gray-400">
+                                Proximity (10%)
+                              </span>
+                              <span className="font-medium">
+                                {interactiveScores.proximity}/10
+                              </span>
+                            </div>
                           </div>
                         </div>
                       </div>
                     </div>
-                  </div>
-                ) : null}
+                  ) : selectedSnapshot ? (
+                    // Read-only mode - show historical snapshot
+                    <div className="grid gap-8 lg:grid-cols-2">
+                      {/* Left: Saved Context and AI Response */}
+                      <div className="space-y-6">
+                        {selectedSnapshot.relationshipGoals && (
+                          <div>
+                            <h3 className="mb-4 text-xl font-bold">
+                              Relationship Context
+                            </h3>
+                            <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                              {selectedSnapshot.relationshipGoals}
+                            </div>
+                          </div>
+                        )}
+
+                        <div>
+                          <div className="rounded-lg border border-indigo-200 bg-indigo-50 p-6 dark:border-indigo-900 dark:bg-indigo-950">
+                            <div className="mb-4 flex items-center justify-between">
+                              <h3 className="text-xl font-bold text-indigo-900 dark:text-indigo-100">
+                                Cosmic Insights from the Stars
+                              </h3>
+                              <button
+                                onClick={() =>
+                                  window.open(
+                                    `/cosmic-insights/${selectedSnapshot.id}`,
+                                    '_blank',
+                                  )
+                                }
+                                className="flex items-center gap-2 rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-indigo-700"
+                              >
+                                <svg
+                                  className="h-4 w-4"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth={2}
+                                    d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                                  />
+                                </svg>
+                                Full Page
+                              </button>
+                            </div>
+                            <div
+                              className="prose prose-sm prose-indigo dark:prose-invert max-w-none text-indigo-800 dark:text-indigo-200 [&_li]:leading-relaxed [&_ul]:space-y-3 [&>div]:space-y-2 [&>p]:mb-4"
+                              dangerouslySetInnerHTML={{
+                                __html: selectedSnapshot.response,
+                              }}
+                            />
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Right: Chart and Score */}
+                      <div className="space-y-6">
+                        {/* Star Chart */}
+                        <div className="rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+                          <h3 className="mb-4 text-xl font-bold">Star Chart</h3>
+                          <div className="relative mx-auto aspect-square w-full">
+                            <svg
+                              viewBox="-10 -10 340 340"
+                              className="h-full w-full"
+                            >
+                              {/* Center point */}
+                              <circle cx="160" cy="160" r="3" fill="#4f46e5" />
+
+                              {/* Concentric circles */}
+                              {[32, 64, 96, 128, 160].map((radius) => (
+                                <circle
+                                  key={radius}
+                                  cx="160"
+                                  cy="160"
+                                  r={radius}
+                                  fill="none"
+                                  stroke="currentColor"
+                                  strokeWidth="1"
+                                  className="stroke-gray-300 dark:stroke-gray-600"
+                                />
+                              ))}
+
+                              {/* Scale labels */}
+                              {[0, 5, 10].map((val) => (
+                                <text
+                                  key={val}
+                                  x="160"
+                                  y={160 - val * 16 - (val === 0 ? 12 : 0) + 5}
+                                  textAnchor="middle"
+                                  fontSize="14"
+                                  fontWeight="500"
+                                  fill="currentColor"
+                                  className="fill-gray-500 dark:fill-gray-400"
+                                >
+                                  {val}
+                                </text>
+                              ))}
+
+                              {/* Axes */}
+                              {Object.keys(selectedSnapshot.scores).map(
+                                (_, idx) => {
+                                  const angle =
+                                    (idx * (360 / 5) - 90 + 30) *
+                                    (Math.PI / 180)
+                                  const x = 160 + 160 * Math.cos(angle)
+                                  const y = 160 + 160 * Math.sin(angle)
+                                  return (
+                                    <line
+                                      key={idx}
+                                      x1="160"
+                                      y1="160"
+                                      x2={x}
+                                      y2={y}
+                                      stroke="currentColor"
+                                      strokeWidth="1"
+                                      className="stroke-gray-300 dark:stroke-gray-600"
+                                    />
+                                  )
+                                },
+                              )}
+
+                              {/* Filled area */}
+                              <path
+                                d={
+                                  Object.values(selectedSnapshot.scores)
+                                    .map((value: number, idx) => {
+                                      const angle =
+                                        (idx * (360 / 5) - 90 + 30) *
+                                        (Math.PI / 180)
+                                      const length = value * 16
+                                      const x = 160 + length * Math.cos(angle)
+                                      const y = 160 + length * Math.sin(angle)
+                                      return `${
+                                        idx === 0 ? 'M' : 'L'
+                                      } ${x} ${y}`
+                                    })
+                                    .join(' ') + ' Z'
+                                }
+                                fill="#4f46e5"
+                                fillOpacity="0.15"
+                                stroke="#4f46e5"
+                                strokeWidth="3"
+                                opacity="0.6"
+                              />
+
+                              {/* Points */}
+                              {Object.values(selectedSnapshot.scores).map(
+                                (value: number, idx) => {
+                                  const angle =
+                                    (idx * (360 / 5) - 90 + 30) *
+                                    (Math.PI / 180)
+                                  const length = value * 16
+                                  const x = 160 + length * Math.cos(angle)
+                                  const y = 160 + length * Math.sin(angle)
+
+                                  return (
+                                    <g key={idx}>
+                                      <circle
+                                        cx={x}
+                                        cy={y}
+                                        r="6"
+                                        fill="#4f46e5"
+                                        stroke="white"
+                                        strokeWidth="2"
+                                      />
+                                    </g>
+                                  )
+                                },
+                              )}
+
+                              {/* Labels */}
+                              {[
+                                { key: 'proximity', label: 'Proximity' },
+                                { key: 'interest', label: 'Interest' },
+                                {
+                                  key: 'personalTime',
+                                  label: 'Personal\nTime',
+                                },
+                                {
+                                  key: 'commonGround',
+                                  label: 'Common\nGround',
+                                },
+                                { key: 'familiarity', label: 'Familiarity' },
+                              ].map((dim, idx) => {
+                                const angle =
+                                  (idx * (360 / 5) - 90 + 30) * (Math.PI / 180)
+                                const labelDistance = 145
+                                const x = 160 + labelDistance * Math.cos(angle)
+                                const y = 160 + labelDistance * Math.sin(angle)
+
+                                return (
+                                  <text
+                                    key={dim.key}
+                                    x={x}
+                                    y={y}
+                                    textAnchor="middle"
+                                    dominantBaseline="middle"
+                                    fontSize="14"
+                                    fontWeight="600"
+                                    fill="currentColor"
+                                    className="fill-gray-700 dark:fill-gray-300"
+                                  >
+                                    {dim.label.split('\n').map((line, i) => (
+                                      <tspan
+                                        key={i}
+                                        x={x}
+                                        dy={i === 0 ? 0 : 16}
+                                      >
+                                        {line}
+                                      </tspan>
+                                    ))}
+                                  </text>
+                                )
+                              })}
+                            </svg>
+                          </div>
+                        </div>
+
+                        {/* Star Score */}
+                        <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+                          <h3 className="mb-4 text-xl font-bold">Star Score</h3>
+                          <div className="mb-4 text-center">
+                            <div className="font-bold">
+                              <span className="text-4xl text-indigo-600 dark:text-indigo-400">
+                                {selectedSnapshot.starScore.toFixed(1)}
+                              </span>
+                              <span className="text-2xl text-gray-400">
+                                /10
+                              </span>
+                            </div>
+                            <div className="mt-2 text-sm font-medium text-gray-600 dark:text-gray-400">
+                              {selectedSnapshot.relationshipLabel}
+                            </div>
+                          </div>
+
+                          <div className="space-y-2 text-sm">
+                            <div className="flex justify-between">
+                              <span className="text-gray-600 dark:text-gray-400">
+                                Personal Time (30%)
+                              </span>
+                              <span className="font-medium">
+                                {selectedSnapshot.scores.personalTime}/10
+                              </span>
+                            </div>
+                            <div className="flex justify-between">
+                              <span className="text-gray-600 dark:text-gray-400">
+                                Common Ground (25%)
+                              </span>
+                              <span className="font-medium">
+                                {selectedSnapshot.scores.commonGround}/10
+                              </span>
+                            </div>
+                            <div className="flex justify-between">
+                              <span className="text-gray-600 dark:text-gray-400">
+                                Familiarity (20%)
+                              </span>
+                              <span className="font-medium">
+                                {selectedSnapshot.scores.familiarity}/10
+                              </span>
+                            </div>
+                            <div className="flex justify-between">
+                              <span className="text-gray-600 dark:text-gray-400">
+                                Interest (15%)
+                              </span>
+                              <span className="font-medium">
+                                {selectedSnapshot.scores.interest}/10
+                              </span>
+                            </div>
+                            <div className="flex justify-between">
+                              <span className="text-gray-600 dark:text-gray-400">
+                                Proximity (10%)
+                              </span>
+                              <span className="font-medium">
+                                {selectedSnapshot.scores.proximity}/10
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ) : null}
                 </div>
               </Dialog.Panel>
             </Transition.Child>

--- a/docs/designs/share-compare-cosmic-insights.md
+++ b/docs/designs/share-compare-cosmic-insights.md
@@ -1,0 +1,252 @@
+# Share & Compare Cosmic Insights - Design Document
+
+## Overview
+
+Allow users to invite others to share their perspective on their relationship,
+then optionally compare both perspectives using AI analysis.
+
+## User Story
+
+1. User A creates Cosmic Insights about their relationship with User B
+2. User A wants to invite User B to share their perspective
+3. User B creates their own Cosmic Insights about the relationship
+4. Both users can optionally request an AI comparison of their different
+   perspectives
+5. Comparison results are shared with both parties
+
+---
+
+## Design Options
+
+### 1. Sharing Mechanism - "Invite to Share Perspective"
+
+#### Option A: Direct Link to Pre-filled Chat
+
+**Flow:**
+
+- Button in modal: "Invite [Name] to Share Their Perspective"
+- Generates URL: `/chat?recipientId=xyz&prefill=true&contextId=assessment123`
+- Opens/creates chat conversation with pre-populated message
+- Message template: "I just reflected on our relationship using Cosmic Insights.
+  I'd love to hear your perspective too! [Link]"
+
+**Pros:**
+
+- Leverages existing chat infrastructure
+- Familiar UX pattern
+- No new pages needed
+- Direct, personal communication
+
+**Cons:**
+
+- Requires chat message prefill functionality (may not exist yet)
+- Less context for recipient
+- Could feel intrusive if they're not expecting it
+
+#### Option B: Dedicated Invitation Landing Page
+
+**Flow:**
+
+- Button: "Invite [Name] to Share Their Perspective"
+- Generates shareable link: `/cosmic-insights/invitation/[token]`
+- Landing page shows:
+  - "Joe invited you to share perspectives on your relationship"
+  - Brief explanation of Cosmic Insights
+  - CTA: "Create Your Cosmic Insights"
+- After completion, prompts to share back
+
+**Pros:**
+
+- Better context and explanation
+- Less intrusive - recipient can choose when to engage
+- Can track invitation status (pending, completed, declined)
+- More professional/polished experience
+
+**Cons:**
+
+- Requires new page and routing
+- More complex implementation
+- Additional database table for invitations
+
+**Recommendation:** Option B provides better UX and sets up infrastructure for
+future features, though Option A is faster to implement.
+
+---
+
+### 2. Comparison Flow - After Both Complete
+
+Once both users have created assessments, enable comparison feature.
+
+#### Components Needed:
+
+1. **Detection:** System detects when both parties have assessments
+2. **Prompt:** UI prompts users to request comparison
+3. **Consent:** Both parties must opt-in to share/compare
+4. **AI Analysis:** Generate comparison using existing
+   `relation_star_comparison` prompt type
+5. **Results Display:** Show side-by-side scores + AI insights
+6. **Sharing:** Send results link via chat to both parties
+
+#### Data Model:
+
+```typescript
+// New table: relation_star_comparisons
+{
+  id: string
+  userAId: string
+  userBId: string
+  assessmentAId: string  // FK to ai_requests
+  assessmentBId: string  // FK to ai_requests
+  comparisonRequestId: string  // FK to ai_requests (the comparison AI response)
+  consentUserA: boolean
+  consentUserB: boolean
+  createdAt: DateTime
+  sharedAt: DateTime?
+}
+```
+
+#### API Endpoints:
+
+- `POST /api/relation-star/compare` - Request comparison (requires both
+  assessments)
+- `GET /api/relation-star/comparison/[id]` - Fetch comparison results
+
+#### UI Pages:
+
+- `/cosmic-insights/comparison/[token]` - Display comparison results
+  - Side-by-side star charts
+  - Individual scores comparison table
+  - AI analysis of differences and suggestions
+
+---
+
+### 3. Privacy & Permissions
+
+#### Key Questions:
+
+1. **Should sender's insights be visible to recipient before they complete their
+   own?**
+
+   - **Recommendation:** No - could bias their assessment
+   - Only show that sender completed it, not the actual scores/insights
+
+2. **Should comparison require explicit consent from both parties?**
+
+   - **Recommendation:** Yes - both must opt-in
+   - Prevents unwanted sharing of private reflections
+
+3. **Who can see comparison results?**
+
+   - **Recommendation:** Both parties, once both consent
+   - Results are shared equally
+
+4. **Can users revoke access to their insights?**
+   - **Future consideration:** Allow users to delete/hide their assessment from
+     comparison
+
+---
+
+## Proposed Implementation Phases
+
+### Phase 1: Simple Share Button (1-2 files, ~2 hours)
+
+**Goal:** Enable basic sharing without complex infrastructure
+
+**Changes:**
+
+- Add "Share Your Perspective" button in `RelationStarModal.tsx`
+- Opens chat with pre-filled message (if chat prefill exists) OR copies
+  shareable link
+- Message contains link to member's profile or `/relation-star-demo`
+- No special landing page - just encourages recipient to create their own
+
+**Files:**
+
+- `apps/web/src/components/RelationStarModal.tsx`
+- Possibly chat component if adding prefill
+
+### Phase 2: Invitation System (3-4 files, ~4 hours)
+
+**Goal:** Proper invitation tracking and landing page
+
+**Changes:**
+
+- Create `cosmic_insights_invitations` table
+- Generate unique invitation tokens
+- Build `/cosmic-insights/invitation/[token]` landing page
+- Track invitation status (pending, accepted, declined)
+- Better recipient UX with context and explanation
+
+**Files:**
+
+- `packages/db/prisma/schema.prisma` - Add invitations table
+- `apps/web/src/app/(main)/cosmic-insights/invitation/[token]/page.tsx` -
+  Landing page
+- `apps/web/src/app/api/cosmic-insights/invitation/route.ts` - Create invitation
+  API
+- `apps/web/src/components/RelationStarModal.tsx` - Add share button
+
+### Phase 3: Comparison Feature (4-5 files, ~6 hours)
+
+**Goal:** AI-powered comparison of both perspectives
+
+**Changes:**
+
+- Create `relation_star_comparisons` table
+- Detect when both parties have assessments
+- Prompt for comparison consent
+- Generate AI comparison using existing prompt type
+- Build comparison results page
+- Send results link via chat
+
+**Files:**
+
+- `packages/db/prisma/schema.prisma` - Add comparisons table
+- `apps/web/src/app/(main)/cosmic-insights/comparison/[token]/page.tsx` -
+  Results page
+- `apps/web/src/app/api/relation-star/compare/route.ts` - Comparison API
+- `apps/web/src/components/RelationStarModal.tsx` - Add comparison prompt
+- `apps/web/src/components/CosmicInsightsComparison.tsx` - Comparison display
+  component
+
+---
+
+## Open Questions
+
+1. **Does the chat system support message prefill?**
+
+   - If not, Phase 1 will just copy a shareable link to clipboard
+
+2. **Should we limit comparison to the most recent assessment from each
+   person?**
+
+   - Or allow comparing any two historical assessments?
+   - **Recommendation:** Most recent only for simplicity
+
+3. **Should there be a notification when the other person completes their
+   assessment?**
+
+   - In-app notification?
+   - Email notification?
+   - Chat message?
+
+4. **Cost considerations for AI comparisons:**
+
+   - Comparison requests will use ~300 input + 400 output tokens
+   - Est. $0.0004 per comparison with gpt-4o-mini
+   - Should we rate-limit comparisons per user?
+
+5. **What happens if one person updates their assessment after comparison?**
+   - Archive old comparison?
+   - Prompt to re-run comparison?
+   - Show "outdated" warning?
+
+---
+
+## Next Steps
+
+1. **Decision:** Which phase to start with?
+2. **Decision:** Resolve open questions above
+3. **Implementation:** Begin with chosen phase
+4. **Testing:** Ensure privacy controls work correctly
+5. **Iteration:** Gather feedback and refine


### PR DESCRIPTION
* Open cosmic insights from modal to new dedicated page. 
* Initially only accessible to owner. 
* Prep for sharing with someone to prompt them to make a Relation Star with Cosmic Insights, then let AI compare them. 
<img width="130" height="45" alt="image" src="https://github.com/user-attachments/assets/b666b32b-dead-41e3-87e4-92bfdab4d0ba" />

* Also updated PWA to have consistent nav buttons like browsers (previous, next, refresh). 
* Before we just had refresh. You can open insights page in new tab (in browser) but iPWA doesn't have tabs so you need a way to navigate back when it opens. 
* Also placed these to the left of logo (top left) for both desktop and mobile PWA. On mobile, only show logo instead of Logo+Name (NameGame, Group Name, etc.) so there's always space for the buttons. 